### PR TITLE
Java 11+ html corrections

### DIFF
--- a/src/main/java/net/obvj/performetrics/util/DurationFormat.java
+++ b/src/main/java/net/obvj/performetrics/util/DurationFormat.java
@@ -5,7 +5,7 @@ package net.obvj.performetrics.util;
  * <p>
  * Examples:
  * </p>
- * <table summary="Duration format examples">
+ * <table>
  * <tr>
  * <td><b>DurationFormat.SHORTER:</b></td>
  * <td>{@code 3.2 second(s)}</td>

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
@@ -93,7 +93,7 @@ public class PrintStyleBuilder
      * The number and sequence of string positions must be defined according to the target
      * stopwatch formatter:
      * </p>
-     * <table summary="Sequence of string positions by PrintFormat">
+     * <table>
      * <tr>
      * <td valign="top"><b>SUMMARIZED:</b></td>
      * <td>
@@ -146,7 +146,7 @@ public class PrintStyleBuilder
      * The number and sequence of string positions must be defined according to the target
      * stopwatch formatter:
      * </p>
-     * <table summary="Sequence of string positions by PrintFormat">
+     * <table>
      * <tr>
      * <td valign="top"><b>SUMMARIZED:</b></td>
      * <td>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -38,7 +38,5 @@
           application, such as context switching, resource allocation, etc.
        </li>
     </ul>
-       
-    </p>
   </body>
 </html>


### PR DESCRIPTION
Removed `sumary` parameter from `Javadoc HTML` tags in order to meet Java `11+` standards.