### PR TITLE
New Print Styles for XML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Test dependencies versions -->
-        <junit.version>5.7.2</junit.version>
+        <junit.version>5.8.2</junit.version>
         <junit-utils.version>1.3.1</junit-utils.version>
-        <mockito.version>3.12.4</mockito.version>
+        <mockito.version>4.6.1</mockito.version>
 
     </properties>
 

--- a/src/main/java/net/obvj/performetrics/util/print/PrintFormat.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintFormat.java
@@ -127,7 +127,8 @@ public enum PrintFormat
             if (style.isPrintHeader())
             {
                 appendLine(builder, style.getAlternativeLine());
-                appendLine(builder, style.getHeaderFormat(), HEADER_SESSION, HEADER_ELAPSED_TIME, HEADER_ELAPSED_TIME_ACC, HEADER_COUNTER);
+                appendLine(builder, style.getHeaderFormat(), HEADER_SESSION, HEADER_ELAPSED_TIME,
+                        HEADER_ELAPSED_TIME_ACC, HEADER_COUNTER);
             }
             Map<Type, List<Counter>> countersByType = stopwatch.getAllCountersByType();
             countersByType.forEach((Type type, List<Counter> counters) ->
@@ -150,7 +151,17 @@ public enum PrintFormat
                     appendLine(builder, style.getSimpleLine());
                     appendLine(builder, toTotalRowFormat(elapsedTimeAcc, style));
                 }
+                if (style.isPrintSectionTrailer())
+                {
+                    appendLine(builder, style.getSimpleLine());
+                    appendLine(builder, style.getSectionTrailerFormat(), type.toString());
+                }
             });
+            if (style.isPrintTrailer())
+            {
+                appendLine(builder, style.getTrailerFormat(), HEADER_SESSION, HEADER_ELAPSED_TIME,
+                        HEADER_ELAPSED_TIME_ACC, HEADER_COUNTER);
+            }
             appendLine(builder, style.getAlternativeLine());
             return builder.toString();
         }

--- a/src/main/java/net/obvj/performetrics/util/print/PrintFormat.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintFormat.java
@@ -67,6 +67,11 @@ public enum PrintFormat
                 appendLine(builder, style.getSimpleLine());
             }
             stopwatch.getTypes().forEach(type -> appendLine(builder, toRowFormat(stopwatch, type, style)));
+            if (style.isPrintTrailer())
+            {
+                appendLine(builder, style.getSimpleLine());
+                appendLine(builder, style.getTrailerFormat(), HEADER_COUNTER, HEADER_ELAPSED_TIME);
+            }
             appendLine(builder, style.getAlternativeLine());
             return builder.toString();
         }

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -372,7 +372,6 @@ public class PrintStyle
      * </pre>
      *
      * @since 2.3.0
-     * @see DurationFormat#ISO_8601
      * @see PrintFormat#DETAILED
      */
     public static final PrintStyle DETAILED_XML = PrintStyle.builder(PrintFormat.DETAILED)

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -536,6 +536,7 @@ public class PrintStyle
      * Returns a flag indicating whether or not the trailer shall be printed.
      *
      * @return a flag indicating whether or not the trailer shall be printed
+     * @since 2.3.0
      */
     public boolean isPrintTrailer()
     {
@@ -558,6 +559,7 @@ public class PrintStyle
      * section in the output.
      *
      * @return a flag indicating whether or not the section trailer shall be printed
+     * @since 2.3.0
      */
     public boolean isPrintSectionTrailer()
     {
@@ -578,6 +580,7 @@ public class PrintStyle
      * Returns the format to be applied to the trailer string of the output.
      *
      * @return the string format to be applied to the trailer
+     * @since 2.3.0
      */
     public String getTrailerFormat()
     {
@@ -618,6 +621,7 @@ public class PrintStyle
      * Returns the format to be applied to the trailer row for each section.
      *
      * @return the format to be applied to the section trailer row(s)
+     * @since 2.3.0
      */
     public String getSectionTrailerFormat()
     {

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -248,7 +248,7 @@ public class PrintStyle
     public static final PrintStyle DETAILED_TABLE_FULL = PrintStyle.builder(PrintFormat.DETAILED)
             .withRowFormat("%5s  %19s  %19s")
             .withHeader()
-            .withSectionHeaderFormat("%s")
+            .withSectionHeader("%s")
             .withSectionSummary("TOTAL %41s")
             .withDurationFormat(DurationFormat.FULL)
             .withoutLegends()
@@ -377,10 +377,10 @@ public class PrintStyle
      */
     public static final PrintStyle DETAILED_XML = PrintStyle.builder(PrintFormat.DETAILED)
             .withHeader("<counters>")
-            .withSectionHeaderFormat("  <counter type=\"%s\">")
+            .withSectionHeader("  <counter type=\"%s\">")
             .withRowFormat("    <session sequence=\"%1$s\">%2$s</session>")
             .withSectionSummary("    <total>%s</total>")
-            .withSectionTrailerFormat("  </counter>")
+            .withSectionTrailer("  </counter>")
             .withTrailer("</counters>")
             .withDurationFormat(DurationFormat.FULL)
             .withoutLegends().build();

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -166,6 +166,54 @@ public class PrintStyle
             .build();
 
     /**
+     * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
+     * in XML format.
+     * <p>
+     * Sample output:
+     *
+     * <pre>
+     * {@code <counters>}
+     * {@code   <counter type="Wall clock time">0:00:01.352886500</counter>}
+     * {@code   <counter type="CPU time">0:00:00.062500000</counter>}
+     * {@code   <counter type="User time">0:00:00.031250000</counter>}
+     * {@code   <counter type="System time">0:00:00.031250000</counter>}
+     * {@code </counters>}
+     * </pre>
+     *
+     * @since 2.3.0
+     * @see PrintFormat#SUMMARIZED
+     */
+    public static final PrintStyle SUMMARIZED_XML = PrintStyle.builder(PrintFormat.SUMMARIZED)
+            .withHeader("<counters>")
+            .withRowFormat("  <counter type=\"%s\">%s</counter>")
+            .withTrailer("</counters>")
+            .withDurationFormat(DurationFormat.FULL)
+            .withoutLegends().build();
+
+    /**
+     * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
+     * as XML with elapsed times expressed using the ISO-8601 duration format.
+     * <p>
+     * Sample output:
+     *
+     * <pre>
+     * {@code <counters>}
+     * {@code   <counter type="Wall clock time">PT1.3528865S</counter>}
+     * {@code   <counter type="CPU time">PT0.0625S</counter>}
+     * {@code   <counter type="User time">PT0.03125S</counter>}
+     * {@code   <counter type="System time">PT0.03125S</counter>}
+     * {@code </counters>}
+     * </pre>
+     *
+     * @since 2.3.0
+     *
+     * @see PrintFormat#SUMMARIZED
+     */
+    public static final PrintStyle SUMMARIZED_XML_ISO_8601 = PrintStyle.builder(SUMMARIZED_XML)
+            .withDurationFormat(DurationFormat.ISO_8601)
+            .build();
+
+    /**
      * A string-based style for the <b>detailed</b> stopwatch formatter, with horizontal lines
      * separating each row, and total elapsed time for each counter.
      * <p>
@@ -308,6 +356,9 @@ public class PrintStyle
     private final boolean printHeader;
     private final String headerFormat;
 
+    private final boolean printTrailer;
+    private final String trailerFormat;
+
     private final String rowFormat;
     private final String sectionHeaderFormat;
 
@@ -359,6 +410,8 @@ public class PrintStyle
         printFormat = builder.getPrintFormat();
         printHeader = builder.isPrintHeader();
         headerFormat = builder.getHeaderFormat();
+        printTrailer = builder.isPrintTrailer();
+        trailerFormat = builder.getTrailerFormat();
         rowFormat = builder.getRowFormat();
         sectionHeaderFormat = builder.getSectionHeaderFormat();
         printSectionSummary = builder.isPrintSectionSummary();
@@ -411,6 +464,16 @@ public class PrintStyle
     }
 
     /**
+     * Returns a flag indicating whether or not the trailer shall be printed.
+     *
+     * @return a flag indicating whether or not the trailer shall be printed
+     */
+    public boolean isPrintTrailer()
+    {
+        return printTrailer;
+    }
+
+    /**
      * Returns a flag indicating whether or not a summary line shall be printed for each
      * section in the output.
      *
@@ -429,6 +492,16 @@ public class PrintStyle
     public String getHeaderFormat()
     {
         return headerFormat;
+    }
+
+    /**
+     * Returns the format to be applied to the trailer string of the output.
+     *
+     * @return the string format to be applied to the trailer
+     */
+    public String getTrailerFormat()
+    {
+        return trailerFormat;
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -206,7 +206,7 @@ public class PrintStyle
      * </pre>
      *
      * @since 2.3.0
-     *
+     * @see DurationFormat#ISO_8601
      * @see PrintFormat#SUMMARIZED
      */
     public static final PrintStyle SUMMARIZED_XML_ISO_8601 = PrintStyle.builder(SUMMARIZED_XML)
@@ -350,6 +350,70 @@ public class PrintStyle
             .withoutHeader()
             .build();
 
+    /**
+     * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data in
+     * XML format.
+     * <p>
+     * Sample output:
+     *
+     * <pre>
+     * {@code <counters>}
+     * {@code   <counter type="Wall clock time">}
+     * {@code     <session sequence="1">0:00:01.371288100</session>}
+     * {@code     <session sequence="2">0:00:01.103620000</session>}
+     * {@code     <total>0:00:02.474908100</total>}
+     * {@code   </counter>}
+     * {@code   <counter type="CPU time">}
+     * {@code     <session sequence="1">0:00:00.031250000</session>}
+     * {@code     <session sequence="2">0:00:00.015625000</session>}
+     * {@code     <total>0:00:00.046875000</total>}
+     * {@code   </counter>}
+     * {@code </counters>}
+     * </pre>
+     *
+     * @since 2.3.0
+     * @see DurationFormat#ISO_8601
+     * @see PrintFormat#DETAILED
+     */
+    public static final PrintStyle DETAILED_XML = PrintStyle.builder(PrintFormat.DETAILED)
+            .withHeader("<counters>")
+            .withSectionHeaderFormat("  <counter type=\"%s\">")
+            .withRowFormat("    <session sequence=\"%1$s\">%2$s</session>")
+            .withSectionSummary("    <total>%s</total>")
+            .withSectionTrailerFormat("  </counter>")
+            .withTrailer("</counters>")
+            .withDurationFormat(DurationFormat.FULL)
+            .withoutLegends().build();
+
+    /**
+     * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data as
+     * XML with elapsed times expressed using the ISO-8601 duration format.
+     * <p>
+     * Sample output:
+     *
+     * <pre>
+     * {@code <counters>}
+     * {@code   <counter type="Wall clock time">}
+     * {@code     <session sequence="1">PT1.357239099S</session>}
+     * {@code     <session sequence="2">PT1.1036874</session>}
+     * {@code     <total>PT2.460926499S</total>}
+     * {@code   </counter>}
+     * {@code   <counter type="CPU time">}
+     * {@code     <session sequence="1">PT0.1875S</session>}
+     * {@code     <session sequence="2">PT0.015625S</session>}
+     * {@code     <total>PT0.203125S</total>}
+     * {@code   </counter>}
+     * {@code </counters>}
+     * </pre>
+     *
+     * @since 2.3.0
+     * @see DurationFormat#ISO_8601
+     * @see PrintFormat#DETAILED
+     */
+    public static final PrintStyle DETAILED_XML_ISO_8601 = PrintStyle.builder(PrintStyle.DETAILED_XML)
+            .withDurationFormat(DurationFormat.ISO_8601)
+            .build();
+
 
     private final PrintFormat printFormat;
 
@@ -364,6 +428,9 @@ public class PrintStyle
 
     private final boolean printSectionSummary;
     private final String sectionSummaryRowFormat;
+
+    private final boolean printSectionTrailer;
+    private final String sectionTrailerFormat;
 
     private final DurationFormat durationFormat;
     private final boolean printLegend;
@@ -416,6 +483,8 @@ public class PrintStyle
         sectionHeaderFormat = builder.getSectionHeaderFormat();
         printSectionSummary = builder.isPrintSectionSummary();
         sectionSummaryRowFormat = builder.getSectionSummaryRowFormat();
+        printSectionTrailer = builder.isPrintSectionTrailer();
+        sectionTrailerFormat = builder.getSectionTrailerFormat();
         durationFormat = builder.getDurationFormat();
         printLegend = builder.isPrintLegend();
         simpleLine = builder.getSimpleLine();
@@ -485,6 +554,17 @@ public class PrintStyle
     }
 
     /**
+     * Returns a flag indicating whether or not a trailer line shall be printed for each
+     * section in the output.
+     *
+     * @return a flag indicating whether or not the section trailer shall be printed
+     */
+    public boolean isPrintSectionTrailer()
+    {
+        return printSectionTrailer;
+    }
+
+    /**
      * Returns the format to be applied to the header string of the output.
      *
      * @return the string format to be applied to the header
@@ -532,6 +612,16 @@ public class PrintStyle
     public String getSectionSummaryRowFormat()
     {
         return sectionSummaryRowFormat;
+    }
+
+    /**
+     * Returns the format to be applied to the trailer row for each section.
+     *
+     * @return the format to be applied to the section trailer row(s)
+     */
+    public String getSectionTrailerFormat()
+    {
+        return sectionTrailerFormat;
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
@@ -243,20 +243,6 @@ public class PrintStyleBuilder
     }
 
     /**
-     * Enables the trailer row, to be formatted using the same row pattern as the header line.
-     * <p>
-     * To specify a different format for the trailer row, use {@link #withTrailer(String)}.
-     *
-     * @return a reference to this builder object for chained calls
-     * @since 2.3.0
-     */
-    public PrintStyleBuilder withTrailer()
-    {
-        printTrailer = true;
-        return this;
-    }
-
-    /**
      * Enables the trailer row and defines a specific format string in printf-style to be
      * applied.
      * <p>
@@ -287,10 +273,6 @@ public class PrintStyleBuilder
      * </ol>
      * </li>
      * </ul>
-     *
-     * <p>
-     * To enable the trailer without specifying a custom format, use the zero-argument option
-     * {@link #withTrailer()}.
      *
      * @param format the format string to be applied for the trailer row
      * @return a reference to this builder object for chained calls
@@ -484,11 +466,6 @@ public class PrintStyleBuilder
         {
             // If the header line is not specified, let the general row format be used
             headerFormat = rowFormat;
-        }
-        if (printTrailer && isEmpty(trailerFormat))
-        {
-            // If the trailer line is not specified, let the same header row format be used
-            trailerFormat = headerFormat;
         }
         if (isEmpty(alternativeLine) && !isEmpty(simpleLine))
         {

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
@@ -239,6 +239,7 @@ public class PrintStyleBuilder
     public PrintStyleBuilder withoutHeader()
     {
         printHeader = false;
+        headerFormat = null;
         return this;
     }
 
@@ -295,6 +296,7 @@ public class PrintStyleBuilder
     public PrintStyleBuilder withoutTrailer()
     {
         printTrailer = false;
+        trailerFormat = null;
         return this;
     }
 
@@ -346,6 +348,7 @@ public class PrintStyleBuilder
     public PrintStyleBuilder withoutSectionTrailer()
     {
         printSectionTrailer = false;
+        sectionTrailerFormat = null;
         return this;
     }
 

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
@@ -280,6 +280,7 @@ public class PrintStyleBuilder
      *
      * @see java.util.Formatter
      * @see PrintStyle
+     * @since 2.3.0
      */
     public PrintStyleBuilder withTrailer(String format)
     {
@@ -292,6 +293,7 @@ public class PrintStyleBuilder
      * Explicitly disables the trailer row.
      *
      * @return a reference to this builder object for chained calls
+     * @since 2.3.0
      */
     public PrintStyleBuilder withoutTrailer()
     {
@@ -344,6 +346,7 @@ public class PrintStyleBuilder
      * Explicitly disables the section trailer row.
      *
      * @return a reference to this builder object for chained calls
+     * @since 2.3.0
      */
     public PrintStyleBuilder withoutSectionTrailer()
     {
@@ -361,6 +364,7 @@ public class PrintStyleBuilder
      *
      * @param format the format string to be applied for the section trailer row
      * @return a reference to this builder object for chained calls
+     * @since 2.3.0
      */
     public PrintStyleBuilder withSectionTrailer(String format)
     {
@@ -516,6 +520,7 @@ public class PrintStyleBuilder
 
     /**
      * @return a flag indicating whether or not the trailer shall be printed
+     * @since 2.3.0
      */
     protected boolean isPrintTrailer()
     {
@@ -533,6 +538,7 @@ public class PrintStyleBuilder
     /**
      * @return a flag indicating whether or not a the trailer row shall be printed for
      *         each section
+     * @since 2.3.0
      */
     protected boolean isPrintSectionTrailer()
     {
@@ -549,6 +555,7 @@ public class PrintStyleBuilder
 
     /**
      * @return the string format to be applied to the table trailer
+     * @since 2.3.0
      */
     protected String getTrailerFormat()
     {
@@ -581,6 +588,7 @@ public class PrintStyleBuilder
 
     /**
      * @return the string format for the each section trailer
+     * @since 2.3.0
      */
     protected String getSectionTrailerFormat()
     {

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
@@ -58,6 +58,9 @@ public class PrintStyleBuilder
     private boolean printSectionSummary;
     private String sectionSummaryRowFormat;
 
+    private boolean printSectionTrailer;
+    private String sectionTrailerFormat;
+
     private DurationFormat durationFormat;
     private boolean printLegend;
 
@@ -101,6 +104,9 @@ public class PrintStyleBuilder
 
         printSectionSummary = source.isPrintSectionSummary();
         sectionSummaryRowFormat = source.getSectionSummaryRowFormat();
+
+        printSectionTrailer = source.isPrintSectionTrailer();
+        sectionTrailerFormat = source.getSectionTrailerFormat();
 
         durationFormat = source.getDurationFormat();
         printLegend = source.isPrintLegend();
@@ -351,6 +357,34 @@ public class PrintStyleBuilder
     }
 
     /**
+     * Explicitly disables the section trailer row.
+     *
+     * @return a reference to this builder object for chained calls
+     */
+    public PrintStyleBuilder withoutSectionTrailer()
+    {
+        printSectionTrailer = false;
+        return this;
+    }
+
+    /**
+     * Enables the section trailer row and defines the format string in printf-style to be
+     * applied.
+     * <p>
+     * <b>Note:</b> The property modified by this method is only applicable for the
+     * <b>detailed</b> stopwatch formatter.
+     *
+     * @param format the format string to be applied for the section trailer row
+     * @return a reference to this builder object for chained calls
+     */
+    public PrintStyleBuilder withSectionTrailerFormat(String format)
+    {
+        printSectionTrailer = true;
+        sectionTrailerFormat = format;
+        return this;
+    }
+
+    /**
      * Defines a simple line, to be generated using the specified character repeated to a
      * given length.
      *
@@ -517,6 +551,15 @@ public class PrintStyleBuilder
     }
 
     /**
+     * @return a flag indicating whether or not a the trailer row shall be printed for
+     *         each section
+     */
+    protected boolean isPrintSectionTrailer()
+    {
+        return printSectionTrailer;
+    }
+
+    /**
      * @return the string format to be applied to the table header
      */
     protected String getHeaderFormat()
@@ -554,6 +597,14 @@ public class PrintStyleBuilder
     protected String getSectionSummaryRowFormat()
     {
         return sectionSummaryRowFormat;
+    }
+
+    /**
+     * @return the string format for the each section trailer
+     */
+    protected String getSectionTrailerFormat()
+    {
+        return sectionTrailerFormat;
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
@@ -322,7 +322,7 @@ public class PrintStyleBuilder
      * @param format the format string to be applied for each section header row
      * @return a reference to this builder object for chained calls
      */
-    public PrintStyleBuilder withSectionHeaderFormat(String format)
+    public PrintStyleBuilder withSectionHeader(String format)
     {
         sectionHeaderFormat = format;
         return this;
@@ -377,7 +377,7 @@ public class PrintStyleBuilder
      * @param format the format string to be applied for the section trailer row
      * @return a reference to this builder object for chained calls
      */
-    public PrintStyleBuilder withSectionTrailerFormat(String format)
+    public PrintStyleBuilder withSectionTrailer(String format)
     {
         printSectionTrailer = true;
         sectionTrailerFormat = format;

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyleBuilder.java
@@ -49,6 +49,9 @@ public class PrintStyleBuilder
     private boolean printHeader;
     private String headerFormat;
 
+    private boolean printTrailer;
+    private String trailerFormat;
+
     private String rowFormat;
     private String sectionHeaderFormat;
 
@@ -89,6 +92,9 @@ public class PrintStyleBuilder
 
         printHeader = source.isPrintHeader();
         headerFormat = source.getHeaderFormat();
+
+        printTrailer = source.isPrintTrailer();
+        trailerFormat = source.getTrailerFormat();
 
         rowFormat = source.getRowFormat();
         sectionHeaderFormat = source.getSectionHeaderFormat();
@@ -227,6 +233,80 @@ public class PrintStyleBuilder
     public PrintStyleBuilder withoutHeader()
     {
         printHeader = false;
+        return this;
+    }
+
+    /**
+     * Enables the trailer row, to be formatted using the same row pattern as the header line.
+     * <p>
+     * To specify a different format for the trailer row, use {@link #withTrailer(String)}.
+     *
+     * @return a reference to this builder object for chained calls
+     * @since 2.3.0
+     */
+    public PrintStyleBuilder withTrailer()
+    {
+        printTrailer = true;
+        return this;
+    }
+
+    /**
+     * Enables the trailer row and defines a specific format string in printf-style to be
+     * applied.
+     * <p>
+     * The number and sequence of string positions must be defined according to the target
+     * stopwatch formatter:
+     * </p>
+     *
+     * <ul>
+     * <li>
+     * <p>
+     * <b>SUMMARIZED</b>
+     * </p>
+     * <ol>
+     * <li>Counter type</li>
+     * <li>Elapsed time</li>
+     * </ol>
+     * </li>
+     *
+     * <li>
+     * <p>
+     * <b>DETAILED</b>
+     * </p>
+     * <ol>
+     * <li>Sequential timing session identifier</li>
+     * <li>Elapsed time</li>
+     * <li>Elapsed time (accumulated)</li>
+     * <li>(Optional) Counter type</li>
+     * </ol>
+     * </li>
+     * </ul>
+     *
+     * <p>
+     * To enable the trailer without specifying a custom format, use the zero-argument option
+     * {@link #withTrailer()}.
+     *
+     * @param format the format string to be applied for the trailer row
+     * @return a reference to this builder object for chained calls
+     *
+     * @see java.util.Formatter
+     * @see PrintStyle
+     */
+    public PrintStyleBuilder withTrailer(String format)
+    {
+        printTrailer = true;
+        trailerFormat = format;
+        return this;
+    }
+
+    /**
+     * Explicitly disables the trailer row.
+     *
+     * @return a reference to this builder object for chained calls
+     */
+    public PrintStyleBuilder withoutTrailer()
+    {
+        printTrailer = false;
         return this;
     }
 
@@ -371,6 +451,11 @@ public class PrintStyleBuilder
             // If the header line is not specified, let the general row format be used
             headerFormat = rowFormat;
         }
+        if (printTrailer && isEmpty(trailerFormat))
+        {
+            // If the trailer line is not specified, let the same header row format be used
+            trailerFormat = headerFormat;
+        }
         if (isEmpty(alternativeLine) && !isEmpty(simpleLine))
         {
             // If the alternative line is not specified let the simple line be used
@@ -416,6 +501,14 @@ public class PrintStyleBuilder
     }
 
     /**
+     * @return a flag indicating whether or not the trailer shall be printed
+     */
+    protected boolean isPrintTrailer()
+    {
+        return printTrailer;
+    }
+
+    /**
      * @return a flag indicating whether or not a summary shall be printed for each section
      */
     protected boolean isPrintSectionSummary()
@@ -429,6 +522,14 @@ public class PrintStyleBuilder
     protected String getHeaderFormat()
     {
         return headerFormat;
+    }
+
+    /**
+     * @return the string format to be applied to the table trailer
+     */
+    protected String getTrailerFormat()
+    {
+        return trailerFormat;
     }
 
     /**

--- a/src/test/java/net/obvj/performetrics/config/ConfigurationHolderTest.java
+++ b/src/test/java/net/obvj/performetrics/config/ConfigurationHolderTest.java
@@ -55,7 +55,7 @@ class ConfigurationHolderTest
     }
 
     @Test
-    void setConfiguration_ValidConfiguration_suceeds()
+    void setConfiguration_validConfiguration_suceeds()
     {
         Configuration newConfiguration = new Configuration();
         newConfiguration.setConversionMode(ConversionMode.FAST);

--- a/src/test/java/net/obvj/performetrics/util/print/PrintFormatTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintFormatTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.*;
 
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -56,14 +57,14 @@ class PrintFormatTest
     static final PrintStyle DETAILED_TEST_STYLE_WITHOUT_TOTALS = PrintStyle.builder(PrintFormat.DETAILED)
             .withoutHeader()
             .withRowFormat("%s %s %s")
-            .withSectionHeaderFormat("%s")
+            .withSectionHeader("%s")
             .withoutSectionSummary()
             .withDurationFormat(DurationFormat.FULL).build();
 
     static final PrintStyle DETAILED_TEST_STYLE_WITH_TOTALS = PrintStyle.builder(PrintFormat.DETAILED)
             .withoutHeader()
             .withRowFormat("%s %s %s")
-            .withSectionHeaderFormat("%s")
+            .withSectionHeader("%s")
             .withSectionSummary("%s")
             .withDurationFormat(DurationFormat.FULL).build();
 
@@ -192,6 +193,37 @@ class PrintFormatTest
     {
         assertThrows(IllegalArgumentException.class,
                 () -> PrintFormat.DETAILED.checkCompatibility(SUMMARIZED_TEST_STYLE));
+    }
+
+    private void assertEachLine(String expected, String actual)
+    {
+        String[] expectedLines = expected.split("\n");
+        String[] actualLine = actual.split("\n");
+        for (int i = 0; i < expectedLines.length; i++)
+        {
+            assertThat(actualLine[i].trim(), equalTo(expectedLines[i].trim()));
+        }
+    }
+
+    @Test
+    void format_detailedXml_properFormating()
+    {
+        String expected
+                = "<counters>\n"
+                + "  <counter type=\"Wall clock time\">\n"
+                + "    <session sequence=\"1\">0:00:01.000000000</session>\n"
+                + "    <session sequence=\"2\">0:00:00.750000000</session>\n"
+                + "    <total>0:00:01.750000000</total>\n"
+                + "  </counter>\n"
+                + "  <counter type=\"CPU time\">\n"
+                + "    <session sequence=\"1\">0:00:00.050000000</session>\n"
+                + "    <session sequence=\"2\">0:00:00.500000000</session>\n"
+                + "    <total>0:00:00.550000000</total>\n"
+                + "  </counter>\n"
+                + "</counters>";
+
+        String result = PrintFormat.DETAILED.format(stopwatch, PrintStyle.DETAILED_XML);
+        assertEachLine(expected, result);
     }
 
 }

--- a/src/test/java/net/obvj/performetrics/util/print/PrintFormatTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintFormatTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static net.obvj.junit.utils.matchers.AdvancedMatchers.*;
 
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -206,21 +205,32 @@ class PrintFormatTest
     }
 
     @Test
+    void format_summarizedXml_properFormating()
+    {
+        String expected = "<counters>\n"
+                        + "  <counter type=\"Wall clock time\">"+ STR_DURATION_SUM_C1 +"</counter>\n"
+                        + "  <counter type=\"CPU time\">" + STR_DURATION_SUM_C2 + "</counter>\n"
+                        + "</counters>";
+
+        String result = PrintFormat.SUMMARIZED.format(stopwatch, PrintStyle.SUMMARIZED_XML);
+        assertEachLine(expected, result);
+    }
+
+    @Test
     void format_detailedXml_properFormating()
     {
-        String expected
-                = "<counters>\n"
-                + "  <counter type=\"Wall clock time\">\n"
-                + "    <session sequence=\"1\">0:00:01.000000000</session>\n"
-                + "    <session sequence=\"2\">0:00:00.750000000</session>\n"
-                + "    <total>0:00:01.750000000</total>\n"
-                + "  </counter>\n"
-                + "  <counter type=\"CPU time\">\n"
-                + "    <session sequence=\"1\">0:00:00.050000000</session>\n"
-                + "    <session sequence=\"2\">0:00:00.500000000</session>\n"
-                + "    <total>0:00:00.550000000</total>\n"
-                + "  </counter>\n"
-                + "</counters>";
+        String expected = "<counters>\n"
+                        + "  <counter type=\"Wall clock time\">\n"
+                        + "    <session sequence=\"1\">" + STR_DURATION_TS1_C1 + "</session>\n"
+                        + "    <session sequence=\"2\">" + STR_DURATION_TS2_C1 + "</session>\n"
+                        + "    <total>"+ STR_DURATION_SUM_C1 +"</total>\n"
+                        + "  </counter>\n"
+                        + "  <counter type=\"CPU time\">\n"
+                        + "    <session sequence=\"1\">" + STR_DURATION_TS1_C2 + "</session>\n"
+                        + "    <session sequence=\"2\">" + STR_DURATION_TS2_C2 + "</session>\n"
+                        + "    <total>" + STR_DURATION_SUM_C2 + "</total>\n"
+                        + "  </counter>\n"
+                        + "</counters>";
 
         String result = PrintFormat.DETAILED.format(stopwatch, PrintStyle.DETAILED_XML);
         assertEachLine(expected, result);

--- a/src/test/java/net/obvj/performetrics/util/print/PrintStyleBuilderTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintStyleBuilderTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -179,6 +181,34 @@ class PrintStyleBuilderTest
         assertThat(newStyle.getSectionHeaderFormat(), is(equalTo(newStyle.getSectionHeaderFormat())));
         assertThat(newStyle.getSectionSummaryRowFormat(), is(equalTo(newStyle.getSectionSummaryRowFormat())));
         assertThat(newStyle.getSimpleLine(), is(equalTo(newStyle.getSimpleLine())));
+    }
+
+    @Test
+    void withoutTrailer_basePrintStyleWithTrailer_false()
+    {
+        PrintStyle baseStyle = new PrintStyleBuilder(PrintFormat.SUMMARIZED).withTrailer("trailer1").build();
+        PrintStyle newStyle = new PrintStyleBuilder(baseStyle).withoutTrailer().build();
+        assertFalse(newStyle.isPrintTrailer());
+        assertNull(newStyle.getTrailerFormat());
+    }
+
+    @Test
+    void withoutSectionTrailer_basePrintStyleWithSectionTrailer_false()
+    {
+        PrintStyle baseStyle = new PrintStyleBuilder(PrintFormat.DETAILED).withSectionTrailer("trailer1").build();
+        PrintStyle newStyle = new PrintStyleBuilder(baseStyle).withoutSectionTrailer().build();
+        assertFalse(newStyle.isPrintSectionTrailer());
+        assertNull(newStyle.getSectionTrailerFormat());
+    }
+
+    @Test
+    void withoutHeader_basePrintStyleWithHeader_false()
+    {
+        String rowFormat = "rowFormat";
+		PrintStyle baseStyle = new PrintStyleBuilder(PrintFormat.DETAILED).withRowFormat(rowFormat).withHeader("header1").build();
+        PrintStyle newStyle = new PrintStyleBuilder(baseStyle).withoutHeader().build();
+        assertFalse(newStyle.isPrintHeader());
+        assertNull(newStyle.getHeaderFormat());
     }
 
 }


### PR DESCRIPTION
This push introduces new preset PrintStyles for printing counters data as XML.

- **`PrintStyle.SUMMARIZED_XML`**

  ````xml
  <counters>
    <counter type="Wall clock time">0:00:01.352886500</counter>
    <counter type="CPU time">0:00:00.062500000</counter>
    <counter type="User time">0:00:00.031250000</counter>
    <counter type="System time">0:00:00.031250000</counter>
  </counters>
  ````

- **`PrintStyle.SUMMARIZED_XML_ISO_8601`**

  ````xml
  <counters>
    <counter type="Wall clock time">PT1.3528865S</counter>
    <counter type="CPU time">PT0.0625S</counter>
    <counter type="User time">PT0.03125S</counter>
    <counter type="System time">PT0.03125S</counter>
  </counters>
  ````

- **`PrintStyle.DETAILED_XML`**

  ````xml
  <counters>
    <counter type="Wall clock time">
      <session sequence="1">0:00:01.371288100</session>
      <session sequence="2">0:00:01.103620000</session>
      <total>0:00:02.474908100</total>
    </counter>
    <counter type="CPU time">
      <session sequence="1">0:00:00.031250000</session>
      <session sequence="2">0:00:00.015625000</session>
      <total>0:00:00.046875000</total>
    </counter>
  </counters>
  ````

- **`PrintStyle.DETAILED_XML_ISO_8601`**

  ````xml
  <counters>
    <counter type="Wall clock time">
      <session sequence="1">PT1.357239099S</session>
      <session sequence="2">PT1.1036874</session>
      <total>PT2.460926499S</total>
    </counter>
    <counter type="CPU time">
      <session sequence="1">PT0.1875S</session>
      <session sequence="2">PT0.015625S</session>
      <total>PT0.203125S</total>
    </counter>
  </counters>
  ````