### PR TITLE
New Print Styles for YAML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <junit.version>5.8.2</junit.version>
         <junit-utils.version>1.3.1</junit-utils.version>
         <mockito.version>4.6.1</mockito.version>
-
+        <snakeyaml.version>1.30</snakeyaml.version>
     </properties>
 
     <dependencies>
@@ -64,6 +64,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/obvj/performetrics/util/DurationFormat.java
+++ b/src/main/java/net/obvj/performetrics/util/DurationFormat.java
@@ -34,7 +34,7 @@ package net.obvj.performetrics.util;
 public enum DurationFormat
 {
     /**
-     * Formats a time duration in the following format: {@code H:M:s:ns}. For example:
+     * Formats a time duration in the following format: {@code H:M:S.ns}. For example:
      * {@code 1:59:59.987654321}
      */
     FULL
@@ -48,8 +48,8 @@ public enum DurationFormat
     },
 
     /**
-     * Formats a time duration in any of the following formats: {@code H:M:s:ns},
-     * {@code M:S:ns}, or {@code S.ns}, always choosing the shortest possible format.
+     * Formats a time duration in any of the following formats: {@code H:M:S.ns},
+     * {@code M:S.ns}, or {@code S.ns}, always choosing the shortest possible format.
      * <p>
      * Examples:
      * <ul>
@@ -79,8 +79,8 @@ public enum DurationFormat
     },
 
     /**
-     * Formats a time duration in any of the following formats: {@code H:M:s:ns},
-     * {@code M:S:ns}, or {@code S.ns}, always choosing the shortest possible format and
+     * Formats a time duration in any of the following formats: {@code H:M:S.ns},
+     * {@code M:S.ns}, or {@code S.ns}, always choosing the shortest possible format and
      * suppressing trailing zeros from the nanoseconds part.
      * <p>
      * Examples:

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -214,6 +214,61 @@ public class PrintStyle
             .build();
 
     /**
+     * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
+     * in YAML format.
+     * <p>
+     * Sample output:
+     *
+     * <pre>
+     * {@code counters:}
+     * {@code - type: Wall clock time}
+     * {@code   value: '0:00:01.352886500'}
+     * {@code - type: CPU time}
+     * {@code   value: '0:00:00.062500000'}
+     * {@code - type: User time}
+     * {@code   value: '0:00:00.031250000'}
+     * {@code - type: System time}
+     * {@code   value: '0:00:00.031250000'}
+     * </pre>
+     *
+     * @since 2.4.0
+     * @see PrintFormat#SUMMARIZED
+     */
+    public static final PrintStyle SUMMARIZED_YAML = PrintStyle.builder(PrintFormat.SUMMARIZED)
+            .withHeader("counters:")
+            .withRowFormat("- type: %s%n  value: '%s'")
+            .withDurationFormat(DurationFormat.FULL)
+            .withoutLegends()
+            .build();
+
+    /**
+     * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
+     * as YAML with elapsed times expressed using the ISO-8601 duration format.
+     * <p>
+     * Sample output:
+     *
+     * <pre>
+     * {@code counters:}
+     * {@code - type: Wall clock time}
+     * {@code   value: PT1.3528865S}
+     * {@code - type: CPU time}
+     * {@code   value: PT0.0625S}
+     * {@code - type: User time}
+     * {@code   value: PT0.03125S}
+     * {@code - type: System time}
+     * {@code   value: PT0.03125S}
+     * </pre>
+     *
+     * @since 2.4.0
+     * @see DurationFormat#ISO_8601
+     * @see PrintFormat#SUMMARIZED
+     */
+    public static final PrintStyle SUMMARIZED_YAML_ISO_8601 = PrintStyle.builder(SUMMARIZED_YAML)
+            .withRowFormat("- type: %s%n  value: %s")
+            .withDurationFormat(DurationFormat.ISO_8601)
+            .build();
+
+    /**
      * A string-based style for the <b>detailed</b> stopwatch formatter, with horizontal lines
      * separating each row, and total elapsed time for each counter.
      * <p>

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -17,11 +17,12 @@
 package net.obvj.performetrics.util.print;
 
 import net.obvj.performetrics.Stopwatch;
+import net.obvj.performetrics.monitors.MonitoredOperation;
 import net.obvj.performetrics.util.DurationFormat;
 
 /**
  * Defines a set of attributes used by a {@link PrintFormat} to generate a String output
- * out of a {@link Stopwatch} object.
+ * out of a {@link Stopwatch} or {@link MonitoredOperation}.
  *
  * @author oswaldo.bapvic.jr
  * @since 2.2.1
@@ -33,6 +34,8 @@ public class PrintStyle
      * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
      * in tabular format without header.
      * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
+     * <p>
      * Sample output:
      *
      * <pre>
@@ -43,6 +46,7 @@ public class PrintStyle
      * </pre>
      *
      * @see PrintFormat#SUMMARIZED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle SUMMARIZED_TABLE_NO_HEADER = PrintStyle.builder(PrintFormat.SUMMARIZED)
             .withRowFormat("%-15s  %19s")
@@ -55,6 +59,8 @@ public class PrintStyle
     /**
      * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
      * in tabular format, with horizontal lines separating each row.
+     * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
      * <p>
      * Sample output:
      *
@@ -70,6 +76,7 @@ public class PrintStyle
      * </pre>
      *
      * @see PrintFormat#SUMMARIZED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle SUMMARIZED_TABLE_FULL = PrintStyle.builder(SUMMARIZED_TABLE_NO_HEADER)
             .withHeader()
@@ -82,6 +89,8 @@ public class PrintStyle
      * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
      * as CSV (comma-separated values).
      * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
+     * <p>
      * Sample output:
      *
      * <pre>
@@ -93,6 +102,7 @@ public class PrintStyle
      * </pre>
      *
      * @see PrintFormat#SUMMARIZED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle SUMMARIZED_CSV = PrintStyle.builder(PrintFormat.SUMMARIZED)
             .withHeader()
@@ -105,6 +115,8 @@ public class PrintStyle
      * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
      * as CSV (comma-separated values), <b>without</b> header.
      * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
+     * <p>
      * Sample output:
      *
      * <pre>
@@ -115,6 +127,7 @@ public class PrintStyle
      * </pre>
      *
      * @see PrintFormat#SUMMARIZED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle SUMMARIZED_CSV_NO_HEADER = PrintStyle.builder(SUMMARIZED_CSV)
             .withoutHeader()
@@ -169,6 +182,8 @@ public class PrintStyle
      * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
      * in XML format.
      * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
+     * <p>
      * Sample output:
      *
      * <pre>
@@ -182,6 +197,7 @@ public class PrintStyle
      *
      * @since 2.3.0
      * @see PrintFormat#SUMMARIZED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle SUMMARIZED_XML = PrintStyle.builder(PrintFormat.SUMMARIZED)
             .withHeader("<counters>")
@@ -217,6 +233,8 @@ public class PrintStyle
      * A string-based style for the <b>summarized</b> stopwatch formatter, which prints data
      * in YAML format.
      * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
+     * <p>
      * Sample output:
      *
      * <pre>
@@ -233,6 +251,7 @@ public class PrintStyle
      *
      * @since 2.4.0
      * @see PrintFormat#SUMMARIZED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle SUMMARIZED_YAML = PrintStyle.builder(PrintFormat.SUMMARIZED)
             .withHeader("counters:")
@@ -272,6 +291,8 @@ public class PrintStyle
      * A string-based style for the <b>detailed</b> stopwatch formatter, with horizontal lines
      * separating each row, and total elapsed time for each counter.
      * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
+     * <p>
      * Sample output:
      *
      * <pre>
@@ -299,6 +320,7 @@ public class PrintStyle
      * </pre>
      *
      * @see PrintFormat#DETAILED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle DETAILED_TABLE_FULL = PrintStyle.builder(PrintFormat.DETAILED)
             .withRowFormat("%5s  %19s  %19s")
@@ -312,8 +334,10 @@ public class PrintStyle
             .build();
 
     /**
-     * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data
-     * as CSV (comma-separated values).
+     * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data as
+     * CSV (comma-separated values).
+     * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
      * <p>
      * Sample output:
      *
@@ -329,6 +353,7 @@ public class PrintStyle
      *
      * @since 2.2.2
      * @see PrintFormat#DETAILED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle DETAILED_CSV = PrintStyle.builder(PrintFormat.DETAILED)
             .withRowFormat("\"%4$s\",%1$s,\"%2$s\",\"%3$s\"")
@@ -339,8 +364,10 @@ public class PrintStyle
             .build();
 
     /**
-     * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data
-     * as CSV (comma-separated values), <b>without</b> header.
+     * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data as
+     * CSV (comma-separated values), <b>without</b> header.
+     * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
      * <p>
      * Sample output:
      *
@@ -355,6 +382,7 @@ public class PrintStyle
      *
      * @since 2.2.2
      * @see PrintFormat#DETAILED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle DETAILED_CSV_NO_HEADER = PrintStyle.builder(DETAILED_CSV)
             .withoutHeader()
@@ -409,6 +437,8 @@ public class PrintStyle
      * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data in
      * XML format.
      * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
+     * <p>
      * Sample output:
      *
      * <pre>
@@ -428,6 +458,7 @@ public class PrintStyle
      *
      * @since 2.3.0
      * @see PrintFormat#DETAILED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle DETAILED_XML = PrintStyle.builder(PrintFormat.DETAILED)
             .withHeader("<counters>")
@@ -473,6 +504,8 @@ public class PrintStyle
      * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data in
      * YAML format.
      * <p>
+     * Elapsed times are expressed in the format {@code H:M:S.ns}.
+     * <p>
      * Sample output:
      *
      * <pre>
@@ -491,6 +524,7 @@ public class PrintStyle
      *
      * @since 2.4.0
      * @see PrintFormat#DETAILED
+     * @see DurationFormat#FULL
      */
     public static final PrintStyle DETAILED_YAML = PrintStyle.builder(PrintFormat.DETAILED)
             .withHeader("counters:")

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -437,7 +437,8 @@ public class PrintStyle
             .withSectionTrailer("  </counter>")
             .withTrailer("</counters>")
             .withDurationFormat(DurationFormat.FULL)
-            .withoutLegends().build();
+            .withoutLegends()
+            .build();
 
     /**
      * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data as
@@ -465,6 +466,68 @@ public class PrintStyle
      * @see PrintFormat#DETAILED
      */
     public static final PrintStyle DETAILED_XML_ISO_8601 = PrintStyle.builder(PrintStyle.DETAILED_XML)
+            .withDurationFormat(DurationFormat.ISO_8601)
+            .build();
+
+    /**
+     * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data in
+     * YAML format.
+     * <p>
+     * Sample output:
+     *
+     * <pre>
+     * {@code counters:}
+     * {@code - type: Wall clock time}
+     * {@code   sessions:}
+     * {@code   - '0:00:01.371288100'}
+     * {@code   - '0:00:01.103620000'}
+     * {@code   total: '0:00:02.474908100'}
+     * {@code - type="CPU time">}
+     * {@code   sessions:}
+     * {@code   - '0:00:00.031250000'}
+     * {@code   - '0:00:00.015625000'}
+     * {@code   total: 0:00:00.046875000}
+     * </pre>
+     *
+     * @since 2.4.0
+     * @see PrintFormat#DETAILED
+     */
+    public static final PrintStyle DETAILED_YAML = PrintStyle.builder(PrintFormat.DETAILED)
+            .withHeader("counters:")
+            .withSectionHeader("- type: %s%n  sessions:")
+            .withRowFormat("  - '%2$s'")
+            .withSectionSummary("  total: '%s'")
+            .withDurationFormat(DurationFormat.FULL)
+            .withoutLegends()
+            .build();
+
+    /**
+     * A string-based style for the <b>detailed</b> stopwatch formatter, which prints data as
+     * YAML with elapsed times expressed using the ISO-8601 duration format.
+     * <p>
+     * Sample output:
+     *
+     * <pre>
+     * {@code counters:}
+     * {@code - type: Wall clock time}
+     * {@code   sessions:}
+     * {@code   - '0:00:01.371288100'}
+     * {@code   - '0:00:01.103620000'}
+     * {@code   total: '0:00:02.474908100'}
+     * {@code - type="CPU time">}
+     * {@code   sessions:}
+     * {@code   - '0:00:00.031250000'}
+     * {@code   - '0:00:00.015625000'}
+     * {@code   total: 0:00:00.046875000}
+     * </pre>
+     *
+     * @since 2.4.0
+     * @see PrintFormat#DETAILED
+     * @see DurationFormat#ISO_8601
+     */
+    public static final PrintStyle DETAILED_YAML_ISO_8601 = PrintStyle.builder(PrintStyle.DETAILED_YAML)
+            .withRowFormat("  - %2$s")
+            .withSectionSummary("  total: %s")
             .withDurationFormat(DurationFormat.ISO_8601)
             .build();
 

--- a/src/test/java/net/obvj/performetrics/util/print/PrintFormatTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintFormatTest.java
@@ -26,13 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
 
 import net.obvj.performetrics.Counter;
 import net.obvj.performetrics.Counter.Type;
@@ -205,7 +203,7 @@ class PrintFormatTest
     }
 
     @Test
-    void format_summarizedXml_properFormating()
+    void format_summarizedXml_properFormatting()
     {
         String expected = "<counters>\n"
                         + "  <counter type=\"Wall clock time\">"+ STR_DURATION_SUM_C1 +"</counter>\n"
@@ -217,7 +215,7 @@ class PrintFormatTest
     }
 
     @Test
-    void format_detailedXml_properFormating()
+    void format_detailedXml_properFormatting()
     {
         String expected = "<counters>\n"
                         + "  <counter type=\"Wall clock time\">\n"
@@ -234,6 +232,61 @@ class PrintFormatTest
 
         String result = PrintFormat.DETAILED.format(stopwatch, PrintStyle.DETAILED_XML);
         assertEachLine(expected, result);
+    }
+
+    /*
+     * Classes for tests using the PrintStyle.SUMMARIZED_YAML
+     */
+    static class CountersSummaryYaml
+    {
+        public List<CounterSummaryYaml> counters;
+    }
+
+    static class CounterSummaryYaml
+    {
+        public String type;
+        public String value;
+    }
+
+    @Test
+    void format_summarizedYaml_properFormatting()
+    {
+        String result = PrintFormat.SUMMARIZED.format(stopwatch, PrintStyle.SUMMARIZED_YAML);
+        CountersSummaryYaml yaml = new Yaml().loadAs(result, CountersSummaryYaml.class);
+        assertThat(yaml.counters.get(0).type, equalTo(WALL_CLOCK_TIME.toString()));
+        assertThat(yaml.counters.get(0).value, equalTo(STR_DURATION_SUM_C1));
+        assertThat(yaml.counters.get(1).type, equalTo(CPU_TIME.toString()));
+        assertThat(yaml.counters.get(1).value, equalTo(STR_DURATION_SUM_C2));
+    }
+
+    /*
+     * Classes for tests using the PrintStyle.DETAILED_YAML
+     */
+    static class CountersDetailsYaml
+    {
+        public List<CounterDetailsYaml> counters;
+    }
+
+    static class CounterDetailsYaml
+    {
+        public String type;
+        public List<String> sessions;
+        public String total;
+    }
+
+    @Test
+    void format_detailedYaml_properFormatting()
+    {
+        String result = PrintFormat.DETAILED.format(stopwatch, PrintStyle.DETAILED_YAML);
+        CountersDetailsYaml yaml = new Yaml().loadAs(result, CountersDetailsYaml.class);
+        assertThat(yaml.counters.get(0).type, equalTo(WALL_CLOCK_TIME.toString()));
+        assertThat(yaml.counters.get(0).sessions.get(0), equalTo(STR_DURATION_TS1_C1));
+        assertThat(yaml.counters.get(0).sessions.get(1), equalTo(STR_DURATION_TS2_C1));
+        assertThat(yaml.counters.get(0).total, equalTo(STR_DURATION_SUM_C1));
+        assertThat(yaml.counters.get(1).type, equalTo(CPU_TIME.toString()));
+        assertThat(yaml.counters.get(1).sessions.get(0), equalTo(STR_DURATION_TS1_C2));
+        assertThat(yaml.counters.get(1).sessions.get(1), equalTo(STR_DURATION_TS2_C2));
+        assertThat(yaml.counters.get(1).total, equalTo(STR_DURATION_SUM_C2));
     }
 
 }


### PR DESCRIPTION
This push introduces new preset PrintStyles for printing counters data as YAML.

- **`PrintStyle.SUMMARIZED_YAML`**

  ````yaml
  counters:
  - type: Wall clock time
    value: '0:00:01.352886500'
  - type: CPU time
    value: '0:00:00.062500000'
  - type: User time
    value: '0:00:00.031250000'
  ````

- **`PrintStyle.SUMMARIZED_YAML_ISO_8601`**

  Same as SUMMARIZED_YAML but durations expressed in ISO-8601 format.

  ````yaml
  counters:
  - type: Wall clock time
    value: PT1.3528865S
  - type: CPU time
    value: PT0.0625S
  - type: User time
    value: PT0.03125S
  ````

- **`PrintStyle.DETAILED_YAML`**

  ````yaml
  counters:
  - type: Wall clock time
    sessions:
    - '0:00:01.371288100'
    - '0:00:01.103620000'
    total: '0:00:02.474908100'
  - type: CPU time
    sessions:
    - '0:00:00.031250000'
    - '0:00:00.015625000'
    total: '0:00:00.046875000'
  ````

- **`PrintStyle.DETAILED_YAML_ISO_8601`**

  Same as DETAILED_YAML but durations expressed in ISO-8601 format.

  ````yaml
  counters:
  - type: Wall clock time
    sessions:
    - PT1.2977679S
    - PT1.1104585S
    - PT1.1111774S
    - PT1.110571S
    total: PT4.6299748S
  - type: CPU time
    sessions:
    - PT0.15625S
    - PT0S
    - PT0.015625S
    - PT0S
    total: PT0.171875S
  - type: User time
    sessions:
    - PT0.109375S
    - PT0S
    - PT0.015625S
    - PT0S
    total: PT0.125S
  - type: System time
    sessions:
    - PT0.046875S
    - PT0S
    - PT0S
    - PT0S
    total: PT0.046875S
  ````