### PR TITLE
Upgrade SnakeYAML to 1.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <junit.version>5.8.2</junit.version>
         <junit-utils.version>1.3.1</junit-utils.version>
         <mockito.version>4.6.1</mockito.version>
-        <snakeyaml.version>1.30</snakeyaml.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Uncontrolled Resource Consumption in snakeyaml:

The package org.yaml:snakeyaml from 0 and before 1.31 are vulnerable to Denial of Service (DoS) due missing to nested depth limitation for collections.