### PR TITLE
New method to retrieve the last session's elapsed time

### DIFF
--- a/src/main/java/net/obvj/performetrics/Counter.java
+++ b/src/main/java/net/obvj/performetrics/Counter.java
@@ -148,7 +148,8 @@ public class Counter
     private long unitsBefore = 0;
     private long unitsAfter = 0;
 
-    private boolean unitsAfterFlag = false;
+    private boolean unitsBeforeSet = false;
+    private boolean unitsAfterSet = false;
 
     /**
      * Builds a Counter with a given type and default time unit.
@@ -220,6 +221,7 @@ public class Counter
     public void setUnitsBefore(long unitsBefore)
     {
         this.unitsBefore = unitsBefore;
+        unitsBeforeSet = true;
     }
 
     /**
@@ -240,7 +242,7 @@ public class Counter
     public void setUnitsAfter(long unitsAfter)
     {
         this.unitsAfter = unitsAfter;
-        unitsAfterFlag = true;
+        unitsAfterSet = true;
     }
 
     /**
@@ -278,7 +280,7 @@ public class Counter
      * Populates the {@code unitsBefore} field with the value retrieved by the time source
      * defined by this counter's type.
      */
-    public void setUnitsBefore()
+    void setUnitsBefore()
     {
         setUnitsBefore(type.getTime(timeUnit));
     }
@@ -287,7 +289,7 @@ public class Counter
      * Populates the {@code unitsAfter} field with the value retrieved by the time source
      * defined by this counter's type.
      */
-    public void setUnitsAfter()
+    void setUnitsAfter()
     {
         setUnitsAfter(type.getTime(timeUnit));
     }
@@ -299,9 +301,10 @@ public class Counter
      *         units are set; or the difference between {@code unitsBefore} and the current
      *         value retrieved by the counter's time source, if {@code unitsAfter} is not set
      */
-    protected long elapsedTimeInternal()
+    long elapsedTimeInternal()
     {
-        long tempUnitsAfter = unitsAfterFlag ? unitsAfter : type.getTime(timeUnit);
+        if (!unitsBeforeSet) return 0;
+        long tempUnitsAfter = unitsAfterSet ? unitsAfter : type.getTime(timeUnit);
         return tempUnitsAfter >= unitsBefore ? tempUnitsAfter - unitsBefore : -1;
     }
 

--- a/src/main/java/net/obvj/performetrics/Counter.java
+++ b/src/main/java/net/obvj/performetrics/Counter.java
@@ -148,7 +148,6 @@ public class Counter
     private long unitsBefore = 0;
     private long unitsAfter = 0;
 
-    private boolean unitsBeforeSet = false;
     private boolean unitsAfterSet = false;
 
     /**
@@ -221,7 +220,6 @@ public class Counter
     public void setUnitsBefore(long unitsBefore)
     {
         this.unitsBefore = unitsBefore;
-        unitsBeforeSet = true;
     }
 
     /**
@@ -303,7 +301,6 @@ public class Counter
      */
     long elapsedTimeInternal()
     {
-        if (!unitsBeforeSet) return 0;
         long tempUnitsAfter = unitsAfterSet ? unitsAfter : type.getTime(timeUnit);
         return tempUnitsAfter >= unitsBefore ? tempUnitsAfter - unitsBefore : -1;
     }

--- a/src/main/java/net/obvj/performetrics/Stopwatch.java
+++ b/src/main/java/net/obvj/performetrics/Stopwatch.java
@@ -130,9 +130,10 @@ import net.obvj.performetrics.util.print.PrintUtils;
  */
 public class Stopwatch
 {
-    protected static final String MSG_NOT_RUNNING = "The stopwatch is not running";
-    protected static final String MSG_TYPE_NOT_SPECIFIED = "\"{0}\" was not assigned during instantiation. Available type(s): {1}";
-    protected static final String MSG_NOT_A_SINGLE_TYPE = "This stopwatch is keeping more than one type. Please inform a specific type for this operation.";
+    static final String MSG_NOT_RUNNING = "The stopwatch is not running";
+    static final String MSG_TYPE_NOT_SPECIFIED = "\"{0}\" was not assigned during instantiation. Available type(s): {1}";
+    static final String MSG_NOT_A_SINGLE_TYPE = "This stopwatch is keeping more than one type. Please inform a specific type for this operation.";
+    static final String MSG_NO_SESSION_FOUND = "No session found";
 
     private static final Type[] DEFAULT_TYPES = Type.values();
 
@@ -570,16 +571,16 @@ public class Stopwatch
     }
 
     /**
-     * Returns the current/last timing session available in this stopwatch, or
-     * {@code TimingSession.EMPTY()} if no timing session available yet.
+     * Returns the current/last timing session available in this stopwatch.
      *
      * @return an {@link Optional} possibly containing the current/last timing session
      *         available in this stopwatch instance
+     * @throws IllegalStateException if this stopwatch does not yet contain any session
      */
     public TimingSession lastSession()
     {
         return new UnmodifiableTimingSession(getLastSession()
-                .orElse(new TimingSession(types.toArray(new Type[types.size()]))));
+                .orElseThrow(() -> new IllegalStateException(MSG_NO_SESSION_FOUND)));
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/Stopwatch.java
+++ b/src/main/java/net/obvj/performetrics/Stopwatch.java
@@ -133,7 +133,7 @@ public class Stopwatch
     static final String MSG_NOT_RUNNING = "The stopwatch is not running";
     static final String MSG_TYPE_NOT_SPECIFIED = "\"{0}\" was not assigned during instantiation. Available type(s): {1}";
     static final String MSG_NOT_A_SINGLE_TYPE = "This stopwatch is keeping more than one type. Please inform a specific type for this operation.";
-    static final String MSG_NO_SESSION_FOUND = "No session found";
+    static final String MSG_NO_SESSION_RECORDED = "No session recorded";
 
     private static final Type[] DEFAULT_TYPES = Type.values();
 
@@ -571,20 +571,19 @@ public class Stopwatch
     }
 
     /**
-     * Returns the current/last timing session available in this stopwatch.
+     * Returns the current/last timing session recorded in this stopwatch.
      *
-     * @return an {@link Optional} possibly containing the current/last timing session
-     *         available in this stopwatch instance
-     * @throws IllegalStateException if this stopwatch does not yet contain any session
+     * @return the current/last timing session recorded in this stopwatch
+     * @throws IllegalStateException if the stopwatch does not contain any recorded session
      */
     public TimingSession lastSession()
     {
         return new UnmodifiableTimingSession(getLastSession()
-                .orElseThrow(() -> new IllegalStateException(MSG_NO_SESSION_FOUND)));
+                .orElseThrow(() -> new IllegalStateException(MSG_NO_SESSION_RECORDED)));
     }
 
     /**
-     * Returns all timing sessions available in this stopwatch.
+     * Returns all timing sessions recorded in this stopwatch.
      *
      * @return a list of timing sessions
      * @since 2.2.0

--- a/src/main/java/net/obvj/performetrics/Stopwatch.java
+++ b/src/main/java/net/obvj/performetrics/Stopwatch.java
@@ -575,6 +575,7 @@ public class Stopwatch
      *
      * @return the current/last timing session recorded in this stopwatch
      * @throws IllegalStateException if the stopwatch does not contain any recorded session
+     * @since 2.4.0
      */
     public TimingSession lastSession()
     {

--- a/src/main/java/net/obvj/performetrics/Stopwatch.java
+++ b/src/main/java/net/obvj/performetrics/Stopwatch.java
@@ -148,14 +148,14 @@ public class Stopwatch
             @Override
             void start(Stopwatch stopwatch)
             {
-                stopwatch.stopCurrentTimingSession();
-                stopwatch.startNewTimingSession();
+                stopwatch.stopCurrentSession();
+                stopwatch.startNewSession();
             }
 
             @Override
             void stop(Stopwatch stopwatch)
             {
-                stopwatch.stopCurrentTimingSession();
+                stopwatch.stopCurrentSession();
             }
         },
 
@@ -164,7 +164,7 @@ public class Stopwatch
             @Override
             void start(Stopwatch stopwatch)
             {
-                stopwatch.startNewTimingSession();
+                stopwatch.startNewSession();
             }
 
             @Override
@@ -310,7 +310,7 @@ public class Stopwatch
      *
      * @return all counters available in this stopwatch instance
      */
-    protected List<Counter> getCounters()
+    List<Counter> getCounters()
     {
         return sessions.stream().map(TimingSession::getCounters).flatMap(Collection::stream)
                 .collect(Collectors.toList());
@@ -537,7 +537,7 @@ public class Stopwatch
      * <b>Note:</b> This method is internal as the current {@link State} defines whether or
      * not this action is allowed.
      */
-    private void startNewTimingSession()
+    private void startNewSession()
     {
         TimingSession session = new TimingSession(types.toArray(new Type[types.size()]));
         sessions.add(session);
@@ -551,9 +551,9 @@ public class Stopwatch
      * <b>Note:</b> This method is internal as the current {@link State} defines whether or
      * not this action is allowed.
      */
-    private void stopCurrentTimingSession()
+    private void stopCurrentSession()
     {
-        getCurrentTimingSession().ifPresent(TimingSession::stop);
+        getLastSession().ifPresent(TimingSession::stop);
         state = State.STOPPED;
     }
 
@@ -564,9 +564,22 @@ public class Stopwatch
      * @return an {@link Optional} possibly containing the current/last timing session
      *         available in this stopwatch instance
      */
-    protected Optional<TimingSession> getCurrentTimingSession()
+    Optional<TimingSession> getLastSession()
     {
         return sessions.isEmpty() ? Optional.empty() : Optional.of(sessions.get(sessions.size() - 1));
+    }
+
+    /**
+     * Returns the current/last timing session available in this stopwatch, or
+     * {@code TimingSession.EMPTY()} if no timing session available yet.
+     *
+     * @return an {@link Optional} possibly containing the current/last timing session
+     *         available in this stopwatch instance
+     */
+    public TimingSession lastSession()
+    {
+        return new UnmodifiableTimingSession(getLastSession()
+                .orElse(new TimingSession(types.toArray(new Type[types.size()]))));
     }
 
     /**
@@ -575,7 +588,7 @@ public class Stopwatch
      * @return a list of timing sessions
      * @since 2.2.0
      */
-    protected List<TimingSession> getTimingSessions()
+    List<TimingSession> getAllSessions()
     {
         return sessions;
     }

--- a/src/main/java/net/obvj/performetrics/TimingSession.java
+++ b/src/main/java/net/obvj/performetrics/TimingSession.java
@@ -85,7 +85,6 @@ public class TimingSession
     private static final String MSG_ALREADY_FINISHED = "A finished timing session cannot be restarted";
     private static final String MSG_TYPE_NOT_SPECIFIED = "\"{0}\" was not specified in this timing session. Available type(s): {1}";
 
-
     private static final Type[] DEFAULT_TYPES = Type.values();
 
     /**
@@ -175,13 +174,18 @@ public class TimingSession
     public TimingSession(Type... types)
     {
         this.types = types;
-        reset();
+        doReset();
     }
 
     /**
      * Resets all counters associated with this timing session.
      */
     public void reset()
+    {
+        doReset();
+    }
+
+    private void doReset()
     {
         counters = new EnumMap<>(Type.class);
         for (Type type : types)
@@ -281,7 +285,7 @@ public class TimingSession
      *
      * @return all counter types specified for this timing session
      */
-    protected Type[] getTypes()
+    Type[] getTypes()
     {
         return types;
     }
@@ -291,7 +295,7 @@ public class TimingSession
      *
      * @return all counters associated with this timing session
      */
-    public Collection<Counter> getCounters()
+    Collection<Counter> getCounters()
     {
         return counters.values();
     }
@@ -303,7 +307,7 @@ public class TimingSession
      * @return the counter instance associated with the given type in this timing session
      * @throws IllegalArgumentException if the type was not specified in this timing session
      */
-    public Counter getCounter(Type type)
+    Counter getCounter(Type type)
     {
         if (!counters.containsKey(type))
         {

--- a/src/main/java/net/obvj/performetrics/UnmodifiableTimingSession.java
+++ b/src/main/java/net/obvj/performetrics/UnmodifiableTimingSession.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.performetrics;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import net.obvj.performetrics.Counter.Type;
+import net.obvj.performetrics.util.Duration;
+
+/**
+ * <p>
+ * A "wrapper" class that allows retrieving values from an existing {@link TimingSession}
+ * but prevents users from modifying it.
+ * </p>
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 2.4.0
+ * @see TimingSession
+ */
+public class UnmodifiableTimingSession extends TimingSession
+{
+    private final TimingSession timingSession;
+
+    /**
+     * Creates an unmodifiable object for a preset {@link TimingSession}.
+     *
+     * @param timingSession the {@link TimingSession} to be wrapped
+     */
+    public UnmodifiableTimingSession(TimingSession timingSession)
+    {
+        this.timingSession = timingSession;
+    }
+
+    private static UnsupportedOperationException unsupportedOperation(String methodName)
+    {
+        return new UnsupportedOperationException(String
+                .format("%s operation received on an unmodifiable TimingSession", methodName));
+    }
+
+    @Override
+    public void reset()
+    {
+        throw unsupportedOperation("reset");
+    }
+
+    @Override
+    public void start()
+    {
+        throw unsupportedOperation("start");
+    }
+
+    @Override
+    public void stop()
+    {
+        throw unsupportedOperation("stop");
+    }
+
+    @Override
+    public boolean isStarted()
+    {
+        return timingSession.isStarted();
+    }
+
+    @Override
+    public Duration elapsedTime(Type type)
+    {
+        return timingSession.elapsedTime(type);
+    }
+
+    @Override
+    public double elapsedTime(Type type, TimeUnit timeUnit)
+    {
+        return timingSession.elapsedTime(type, timeUnit);
+    }
+
+    @Override
+    public double elapsedTime(Type type, TimeUnit timeUnit, ConversionMode conversionMode)
+    {
+        return timingSession.elapsedTime(type, timeUnit, conversionMode);
+    }
+
+    @Override
+    Type[] getTypes()
+    {
+        return timingSession.getTypes();
+    }
+
+    @Override
+    Collection<Counter> getCounters()
+    {
+        return timingSession.getCounters();
+    }
+
+    @Override
+    Counter getCounter(Type type)
+    {
+        return timingSession.getCounter(type);
+    }
+
+}

--- a/src/main/java/net/obvj/performetrics/util/Duration.java
+++ b/src/main/java/net/obvj/performetrics/util/Duration.java
@@ -59,6 +59,7 @@ public class Duration implements Comparable<Duration>
     private static final String MSG_SOURCE_TIME_UNIT_MUST_NOT_BE_NULL = "The source TimeUnit must not be null";
     private static final String MSG_TARGET_TIME_UNIT_MUST_NOT_BE_NULL = "The target TimeUnit must not be null";
     private static final String MSG_FORMAT_MUST_NOT_BE_NULL = "The format must not be null";
+    private static final String MSG_AMOUNT_MUST_BE_POSITIVE = "The duration amount must be a positive value";
 
     private static final int SECONDS_PER_MINUTE = 60;
     private static final int SECONDS_PER_HOUR = 60 * 60;
@@ -88,14 +89,20 @@ public class Duration implements Comparable<Duration>
      * duration.getNanoseconds() //returns: 0
      * </pre>
      *
-     * @param amount   the amount of the duration, measured in terms of the time unit argument
+     * @param amount   the amount of the duration, measured in terms of the time unit
+     *                 argument, not negative
      * @param timeUnit the unit that the amount argument is measured in, not null
      * @return a {@code Duration}, not null
      *
-     * @throws NullPointerException if the specified time unit is null
+     * @throws NullPointerException     if the specified time unit is null
+     * @throws IllegalArgumentException if the specified duration amount is negative
      */
     public static Duration of(long amount, TimeUnit timeUnit)
     {
+        if (amount < 0)
+        {
+            throw new IllegalArgumentException(MSG_AMOUNT_MUST_BE_POSITIVE);
+        }
         Objects.requireNonNull(timeUnit, MSG_SOURCE_TIME_UNIT_MUST_NOT_BE_NULL);
         ChronoUnit chronoUnit = TimeUnitConverter.toChronoUnit(timeUnit);
         java.time.Duration internalDuration = java.time.Duration.of(amount, chronoUnit);

--- a/src/test/java/net/obvj/performetrics/CounterTest.java
+++ b/src/test/java/net/obvj/performetrics/CounterTest.java
@@ -174,6 +174,7 @@ class CounterTest
     {
         Counter counter = new Counter(SYSTEM_TIME, SECONDS, FAST);
         assertThat(counter.getTimeUnit(), is(SECONDS));
+        counter.setUnitsBefore(0);
         counter.setUnitsAfter(59); // 59 seconds after
         assertThat(counter.elapsedTime(MINUTES), is(equalTo(0.0)));
     }
@@ -183,6 +184,7 @@ class CounterTest
     {
         Counter counter = new Counter(SYSTEM_TIME, SECONDS, DOUBLE_PRECISION);
         assertThat(counter.getTimeUnit(), is(SECONDS));
+        counter.setUnitsBefore(0);
         counter.setUnitsAfter(59); // 59 seconds after
         assertThat(counter.elapsedTime(MINUTES), is(equalTo(0.983333333)));
     }
@@ -192,6 +194,7 @@ class CounterTest
     {
         Counter counter = new Counter(SYSTEM_TIME, SECONDS, FAST);
         assertThat(counter.getTimeUnit(), is(SECONDS));
+        counter.setUnitsBefore(0);
         counter.setUnitsAfter(2); // 2 seconds
         assertThat(counter.elapsedTime(MILLISECONDS), is(equalTo(2000.0)));
     }
@@ -201,6 +204,7 @@ class CounterTest
     {
         Counter counter = new Counter(SYSTEM_TIME, SECONDS, DOUBLE_PRECISION);
         assertThat(counter.getTimeUnit(), is(SECONDS));
+        counter.setUnitsBefore(0);
         counter.setUnitsAfter(2); // 2 seconds
         assertThat(counter.elapsedTime(MILLISECONDS), is(equalTo(2000.0)));
     }

--- a/src/test/java/net/obvj/performetrics/CounterTest.java
+++ b/src/test/java/net/obvj/performetrics/CounterTest.java
@@ -174,7 +174,6 @@ class CounterTest
     {
         Counter counter = new Counter(SYSTEM_TIME, SECONDS, FAST);
         assertThat(counter.getTimeUnit(), is(SECONDS));
-        counter.setUnitsBefore(0);
         counter.setUnitsAfter(59); // 59 seconds after
         assertThat(counter.elapsedTime(MINUTES), is(equalTo(0.0)));
     }
@@ -184,7 +183,6 @@ class CounterTest
     {
         Counter counter = new Counter(SYSTEM_TIME, SECONDS, DOUBLE_PRECISION);
         assertThat(counter.getTimeUnit(), is(SECONDS));
-        counter.setUnitsBefore(0);
         counter.setUnitsAfter(59); // 59 seconds after
         assertThat(counter.elapsedTime(MINUTES), is(equalTo(0.983333333)));
     }
@@ -194,7 +192,6 @@ class CounterTest
     {
         Counter counter = new Counter(SYSTEM_TIME, SECONDS, FAST);
         assertThat(counter.getTimeUnit(), is(SECONDS));
-        counter.setUnitsBefore(0);
         counter.setUnitsAfter(2); // 2 seconds
         assertThat(counter.elapsedTime(MILLISECONDS), is(equalTo(2000.0)));
     }
@@ -204,7 +201,6 @@ class CounterTest
     {
         Counter counter = new Counter(SYSTEM_TIME, SECONDS, DOUBLE_PRECISION);
         assertThat(counter.getTimeUnit(), is(SECONDS));
-        counter.setUnitsBefore(0);
         counter.setUnitsAfter(2); // 2 seconds
         assertThat(counter.elapsedTime(MILLISECONDS), is(equalTo(2000.0)));
     }

--- a/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
@@ -69,7 +69,6 @@ public class PerformetricsTestDrive
     private static void test(Stopwatch sw) throws InterruptedException, IOException
     {
         // Enforcing some wall-clock time...
-
         int sleepTimeMillis = new Random(9999).nextInt(3000);
         Thread.sleep(sleepTimeMillis);
 
@@ -83,13 +82,19 @@ public class PerformetricsTestDrive
         sw.stop();
 
         System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME));
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.NANOSECONDS) + " nanosecods");
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.NANOSECONDS) + " nanosecods");
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.MILLISECONDS) + " millisecods");
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.MILLISECONDS) + " millisecods");
+        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.NANOSECONDS) + " nanoseconds");
+        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.NANOSECONDS) + " nanoseconds");
+        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.MILLISECONDS) + " milliseconds");
+        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.MILLISECONDS) + " milliseconds");
         System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.SECONDS) + " seconds");
         System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.SECONDS) + " seconds");
+
         sw.printDetails(System.out);
+
+        System.out.println("\nSESSION CHECK:");
+        System.out.println(" - Last elapsed time (WALL_CLOCK_TIME): " + sw.lastSession().elapsedTime(Type.WALL_CLOCK_TIME));
+        System.out.println(" - Last elapsed time (CPU_TIME): "        + sw.lastSession().elapsedTime(Type.CPU_TIME));
+        System.out.println();
     }
 
     private static void testCallableWithLambda() throws Exception

--- a/src/test/java/net/obvj/performetrics/StopwatchTest.java
+++ b/src/test/java/net/obvj/performetrics/StopwatchTest.java
@@ -739,10 +739,11 @@ class StopwatchTest
     }
 
     @Test
-    void lastSession_unstartedStopwatch_exception()
+    void lastSession_unstartedStopwatch_illegalStateException()
     {
         Stopwatch sw = new Stopwatch();
-        assertThat(() -> sw.lastSession(), throwsException(IllegalStateException.class));
+        assertThat(() -> sw.lastSession(), throwsException(IllegalStateException.class)
+                .withMessage(Stopwatch.MSG_NO_SESSION_RECORDED));
     }
 
     @Test

--- a/src/test/java/net/obvj/performetrics/UnmodifiableTimingSessionTest.java
+++ b/src/test/java/net/obvj/performetrics/UnmodifiableTimingSessionTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2023 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.performetrics;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static net.obvj.performetrics.ConversionMode.DOUBLE_PRECISION;
+import static net.obvj.performetrics.ConversionMode.FAST;
+import static net.obvj.performetrics.Counter.Type.CPU_TIME;
+import static net.obvj.performetrics.Counter.Type.SYSTEM_TIME;
+import static net.obvj.performetrics.Counter.Type.USER_TIME;
+import static net.obvj.performetrics.Counter.Type.WALL_CLOCK_TIME;
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import net.obvj.performetrics.Counter.Type;
+import net.obvj.performetrics.util.Duration;
+import net.obvj.performetrics.util.SystemUtils;
+
+/**
+ * Unit tests for the {@link UnmodifiableTimingSession} class.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 2.3.0
+ */
+class UnmodifiableTimingSessionTest
+{
+    private static final long WALL_CLOCK_TIME_BEFORE = 2000000000l;
+    private static final long CPU_TIME_BEFORE = 1200000000l;
+    private static final long USER_TIME_BEFORE = 1200000001l;
+    private static final long SYSTEM_TIME_BEFORE = 1200000002l;
+
+    private static final long WALL_CLOCK_TIME_AFTER = 3000000000l;
+    private static final long CPU_TIME_AFTER = 1200000300l;
+    private static final long USER_TIME_AFTER = 1200000201l;
+    private static final long SYSTEM_TIME_AFTER = 1200000102l;
+
+    /**
+     * Setup the expects on PerformetricUtils mock with "_BEFORE" constant values
+     */
+    private void setupExpectsBefore(MockedStatic<SystemUtils> systemUtils)
+    {
+        systemUtils.when(SystemUtils::getWallClockTimeNanos).thenReturn(WALL_CLOCK_TIME_BEFORE);
+        systemUtils.when(SystemUtils::getCpuTimeNanos).thenReturn(CPU_TIME_BEFORE);
+        systemUtils.when(SystemUtils::getUserTimeNanos).thenReturn(USER_TIME_BEFORE);
+        systemUtils.when(SystemUtils::getSystemTimeNanos).thenReturn(SYSTEM_TIME_BEFORE);
+    }
+
+    /**
+     * Setup the expects on PerformetricUtils mock with "_AFTER" constant values
+     */
+    private void setupExpectsAfter(MockedStatic<SystemUtils> systemUtils)
+    {
+        systemUtils.when(SystemUtils::getWallClockTimeNanos).thenReturn(WALL_CLOCK_TIME_AFTER);
+        systemUtils.when(SystemUtils::getCpuTimeNanos).thenReturn(CPU_TIME_AFTER);
+        systemUtils.when(SystemUtils::getUserTimeNanos).thenReturn(USER_TIME_AFTER);
+        systemUtils.when(SystemUtils::getSystemTimeNanos).thenReturn(SYSTEM_TIME_AFTER);
+    }
+
+    private Counter getCounter(TimingSession timingSession, Type type)
+    {
+        return timingSession.getCounter(type);
+    }
+
+    @Test
+    void getAllCounters_allCounters_sameValueAsOriginalObject()
+    {
+        TimingSession original = new TimingSession();
+        TimingSession unmodifiable = new UnmodifiableTimingSession(original);
+        assertThat(unmodifiable.getTypes(), equalTo(original.getTypes()));
+        assertThat(unmodifiable.getCounters(), equalTo(original.getCounters()));
+    }
+
+    @Test
+    void getAllCounters_customCounters_sameValueAsOriginalObject()
+    {
+        TimingSession original = new TimingSession(USER_TIME);
+        TimingSession unmodifiable = new UnmodifiableTimingSession(original);
+        assertThat(unmodifiable.getTypes(), equalTo(original.getTypes()));
+        assertThat(unmodifiable.getCounters(), equalTo(original.getCounters()));
+    }
+
+    @Test
+    void start_unsupportedOperation()
+    {
+        TimingSession unmodifiable = new UnmodifiableTimingSession(new TimingSession(USER_TIME));
+        assertThat(() -> unmodifiable.start(),
+                throwsException(UnsupportedOperationException.class));
+    }
+
+    @Test
+    void stop_unsupportedOperation()
+    {
+        TimingSession unmodifiable = new UnmodifiableTimingSession(new TimingSession(USER_TIME));
+        assertThat(() -> unmodifiable.stop(),
+                throwsException(UnsupportedOperationException.class));
+    }
+
+    @Test
+    void reset_unsupportedOperation()
+    {
+        TimingSession unmodifiable = new UnmodifiableTimingSession(new TimingSession(USER_TIME));
+        assertThat(() -> unmodifiable.reset(),
+                throwsException(UnsupportedOperationException.class));
+    }
+
+    @Test
+    void getCounter_invalidType_throwsException()
+    {
+        TimingSession session = new TimingSession(CPU_TIME, SYSTEM_TIME);
+        assertThrows(IllegalArgumentException.class, () -> getCounter(session, USER_TIME));
+    }
+
+    @Test()
+    void elapsedTime_validType_returnsValidDurations()
+    {
+        TimingSession original = new TimingSession();
+        try (MockedStatic<SystemUtils> systemUtils = mockStatic(SystemUtils.class))
+        {
+            setupExpectsBefore(systemUtils);
+            original.start();
+            setupExpectsAfter(systemUtils);
+
+            TimingSession session = new UnmodifiableTimingSession(original);
+            assertThat(session.elapsedTime(WALL_CLOCK_TIME),
+                    is(equalTo(Duration.of(WALL_CLOCK_TIME_AFTER - WALL_CLOCK_TIME_BEFORE, NANOSECONDS))));
+            assertThat(session.elapsedTime(CPU_TIME),
+                    is(equalTo(Duration.of(CPU_TIME_AFTER - CPU_TIME_BEFORE, NANOSECONDS))));
+            assertThat(session.elapsedTime(USER_TIME),
+                    is(equalTo(Duration.of(USER_TIME_AFTER - USER_TIME_BEFORE, NANOSECONDS))));
+            assertThat(session.elapsedTime(SYSTEM_TIME),
+                    is(equalTo(Duration.of(SYSTEM_TIME_AFTER - SYSTEM_TIME_BEFORE, NANOSECONDS))));
+        }
+    }
+
+    @Test()
+    void elapsedTime_validTypeAndTimeUnit_callsCorrectElapsedTimeFromCounters()
+    {
+        TimingSession original = new TimingSession();
+        try (MockedStatic<SystemUtils> systemUtils = mockStatic(SystemUtils.class))
+        {
+            setupExpectsBefore(systemUtils);
+            original.start();
+            setupExpectsAfter(systemUtils);
+
+            TimingSession session = new UnmodifiableTimingSession(original);
+            assertThat(session.elapsedTime(WALL_CLOCK_TIME, SECONDS),
+                    is(equalTo(getCounter(session, WALL_CLOCK_TIME).elapsedTime(SECONDS))));
+            assertThat(session.elapsedTime(CPU_TIME, MILLISECONDS),
+                    is(equalTo(getCounter(session, CPU_TIME).elapsedTime(MILLISECONDS))));
+            assertThat(session.elapsedTime(USER_TIME, NANOSECONDS),
+                    is(equalTo(getCounter(session, USER_TIME).elapsedTime(NANOSECONDS))));
+            assertThat(session.elapsedTime(SYSTEM_TIME, SECONDS),
+                    is(equalTo(getCounter(session, SYSTEM_TIME).elapsedTime(SECONDS))));
+        }
+    }
+
+    @Test()
+    void elapsedTime_validTypeAndTimeUnitAndConversionMode_callsCorrectElapsedTimeFromCounters()
+    {
+        TimingSession original = new TimingSession();
+        try (MockedStatic<SystemUtils> systemUtils = mockStatic(SystemUtils.class))
+        {
+            setupExpectsBefore(systemUtils);
+            original.start();
+            setupExpectsAfter(systemUtils);
+
+            TimingSession session = new UnmodifiableTimingSession(original);
+            assertThat(session.elapsedTime(WALL_CLOCK_TIME, SECONDS, FAST),
+                    is(equalTo(getCounter(session, WALL_CLOCK_TIME).elapsedTime(SECONDS, FAST))));
+            assertThat(session.elapsedTime(CPU_TIME, MILLISECONDS, DOUBLE_PRECISION),
+                    is(equalTo(getCounter(session, CPU_TIME).elapsedTime(MILLISECONDS, DOUBLE_PRECISION))));
+            assertThat(session.elapsedTime(USER_TIME, NANOSECONDS, FAST),
+                    is(equalTo(getCounter(session, USER_TIME).elapsedTime(NANOSECONDS, FAST))));
+            assertThat(session.elapsedTime(SYSTEM_TIME, HOURS, DOUBLE_PRECISION),
+                    is(equalTo(getCounter(session, SYSTEM_TIME).elapsedTime(HOURS, DOUBLE_PRECISION))));
+        }
+    }
+
+}

--- a/src/test/java/net/obvj/performetrics/util/DurationTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationTest.java
@@ -17,8 +17,7 @@
 package net.obvj.performetrics.util;
 
 import static java.util.concurrent.TimeUnit.*;
-import static net.obvj.junit.utils.matchers.AdvancedMatchers.isNegative;
-import static net.obvj.junit.utils.matchers.AdvancedMatchers.isPositive;
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -56,6 +55,14 @@ class DurationTest
         assertThat(td1.getMinutes(),     is(equalTo(30)));
         assertThat(td1.getSeconds(),     is(equalTo(10)));
         assertThat(td1.getNanoseconds(), is(equalTo(0)));
+    }
+
+    @Test
+    void of_negativeAmount_illegalArgumentException()
+    {
+        assertThat(() -> Duration.of(-1, NANOSECONDS),
+                throwsException(IllegalArgumentException.class)
+                        .withMessage("The duration amount must be a positive value"));
     }
 
     @Test


### PR DESCRIPTION
This enhancement introduces:
- New `UnmodifiableTimingSession` class
- New method `Stopwatch.lastSession()` to retrieve an unmodifiable copy of the last session, allowing the call `stopwatch.lastSession().elapsedTime()`
- Fix in the `Duration.of` factory method, to avoid negative duration amounts 