### PR TITLE
New print methods in Stopwatch and MonitoredOperation

### DIFF
--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -89,7 +89,7 @@ public class Performetrics
      * @param printStyle the {@link PrintStyle} to be set; not null
      * @throws NullPointerException if the specified {@code PrintStyle} is null
      *
-     * @since 2.2.1
+     * @since 2.4.0
      */
     public static void setDefaultPrintStyle(PrintStyle printStyle)
     {

--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -75,6 +75,28 @@ public class Performetrics
     }
 
     /**
+     * Defines the default {@link PrintStyle} to be applied when no style is specified.
+     * <p>
+     * The object will be used by the following operations:
+     * </p>
+     * <ul>
+     * <li>{@link Stopwatch#print(java.io.PrintStream)}</li>
+     * <li>{@link Stopwatch#toString()}</li>
+     * <li>{@link MonitoredOperation#print(java.io.PrintStream)}</li>
+     * <li>{@link MonitoredOperation#toString()}</li>
+     * </ul>
+     *
+     * @param printStyle the {@link PrintStyle} to be set; not null
+     * @throws NullPointerException if the specified {@code PrintStyle} is null
+     *
+     * @since 2.2.1
+     */
+    public static void setDefaultPrintStyle(PrintStyle printStyle)
+    {
+        ConfigurationHolder.getConfiguration().setPrintStyleForSummary(printStyle);
+    }
+
+    /**
      * Defines the default {@link PrintStyle} to be applied by the summarized stopwatch
      * formatter.
      * <p>
@@ -86,7 +108,7 @@ public class Performetrics
      * </ul>
      *
      * @param printStyle the {@link PrintStyle} to be set; not null
-     * @throws NullPointerException if the specified PrintStyle is null
+     * @throws NullPointerException if the specified {@code PrintStyle} is null
      *
      * @since 2.2.1
      */
@@ -107,7 +129,7 @@ public class Performetrics
      * </ul>
      *
      * @param printStyle the {@link PrintStyle} to be set; not null
-     * @throws NullPointerException if the specified PrintStyle is null
+     * @throws NullPointerException if the specified {@code PrintStyle} is null
      *
      * @since 2.2.1
      */

--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -93,7 +93,7 @@ public class Performetrics
      */
     public static void setDefaultPrintStyle(PrintStyle printStyle)
     {
-        ConfigurationHolder.getConfiguration().setPrintStyleForSummary(printStyle);
+        ConfigurationHolder.getConfiguration().setPrintStyle(printStyle);
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/Stopwatch.java
+++ b/src/main/java/net/obvj/performetrics/Stopwatch.java
@@ -471,11 +471,40 @@ public class Stopwatch
     }
 
     /**
+     * Prints elapsed times in the specified print stream with default summary style.
+     *
+     * @param printStream the print stream to which data will be sent
+     * @throws NullPointerException if the {@code PrintStream} is null
+     * @since 2.4.0
+     */
+    public void print(PrintStream printStream)
+    {
+        PrintUtils.print(this, printStream);
+    }
+
+    /**
+     * Prints elapsed times in the specified print stream with a custom {@link PrintStyle}.
+     * <p>
+     * The format (whether to generate a summarized or detailed view) will be determined by
+     * the specified {@link PrintStyle}.
+     *
+     * @param printStream the print stream to which data will be sent
+     * @param printStyle  the {@link PrintStyle} to be applied
+     *
+     * @throws NullPointerException if the {@code PrintStream} is null
+     * @since 2.4.0
+     */
+    public void print(PrintStream printStream, PrintStyle printStyle)
+    {
+        PrintUtils.print(this, printStream, printStyle);
+    }
+
+    /**
      * Prints summarized elapsed times in the specified print stream.
      *
      * @param printStream the print stream to which data will be sent
      *
-     * @throws NullPointerException if the PrintStream is null
+     * @throws NullPointerException if the {@code PrintStream} is null
      *
      * @since 2.2.1
      */
@@ -491,9 +520,9 @@ public class Stopwatch
      * @param printStream the print stream to which data will be sent
      * @param printStyle  the {@link PrintStyle} to be applied
      *
-     * @throws NullPointerException     if the PrintStream is null
-     * @throws IllegalArgumentException if the specified PrintStyle is not compatible with
-     *                                  {@link PrintFormat#SUMMARIZED}
+     * @throws NullPointerException     if the {@code PrintStream} is null
+     * @throws IllegalArgumentException if the specified {@code PrintStyle} is not compatible
+     *                                  with {@link PrintFormat#SUMMARIZED}
      * @since 2.2.1
      */
     public void printSummary(PrintStream printStream, PrintStyle printStyle)
@@ -506,7 +535,7 @@ public class Stopwatch
      *
      * @param printStream the print stream to which information will be sent
      *
-     * @throws NullPointerException if the PrintStream is null
+     * @throws NullPointerException if the {@code PrintStream} is null
      *
      * @since 2.2.1
      */
@@ -522,9 +551,9 @@ public class Stopwatch
      * @param printStream the print stream to which information will be sent
      * @param printStyle  the {@link PrintStyle} to be applied
      *
-     * @throws NullPointerException     if the PrintStream is null
-     * @throws IllegalArgumentException if the specified PrintStyle is not compatible with
-     *                                  {@link PrintFormat#DETAILED}
+     * @throws NullPointerException     if the {@code PrintStream} is null
+     * @throws IllegalArgumentException if the specified {@code PrintStyle} is not compatible
+     *                                  with {@link PrintFormat#DETAILED}
      * @since 2.2.1
      */
     public void printDetails(PrintStream printStream, PrintStyle printStyle)
@@ -595,14 +624,28 @@ public class Stopwatch
     }
 
     /**
-     * Returns a string containing a formatted stopwatch summary.
+     * Returns a string containing a formatted stopwatch summary in default style.
      *
-     * @return a string containing stopwatch summary
+     * @return a string containing a stopwatch summary in default style
      * @since 2.2.4
      */
     @Override
     public String toString()
     {
-        return PrintUtils.summaryToString(this);
+        return PrintUtils.toString(this);
+    }
+
+    /**
+     * Returns a string containing a formatted stopwatch summary in a custom
+     * {@link PrintStyle}.
+     *
+     * @param printStyle the {@link PrintStyle} to be applied; if {@code null}, the default
+     *                   {@code PrintStyle} will be applied
+     * @return a string containing stopwatch summary in the specified {@link PrintStyle}
+     * @since 2.4.0
+     */
+    public String toString(PrintStyle printStyle)
+    {
+        return PrintUtils.toString(this, printStyle);
     }
 }

--- a/src/main/java/net/obvj/performetrics/Stopwatch.java
+++ b/src/main/java/net/obvj/performetrics/Stopwatch.java
@@ -471,7 +471,12 @@ public class Stopwatch
     }
 
     /**
-     * Prints elapsed times in the specified print stream with default summary style.
+     * Prints elapsed times in the specified print stream.
+     * <p>
+     * The default {@link PrintStyle} (defined by
+     * {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be applied.
+     * <p>
+     * For a custom {@code PrintStyle}, use {@link #print(PrintStream, PrintStyle)}.
      *
      * @param printStream the print stream to which data will be sent
      * @throws NullPointerException if the {@code PrintStream} is null
@@ -489,7 +494,10 @@ public class Stopwatch
      * the specified {@link PrintStyle}.
      *
      * @param printStream the print stream to which data will be sent
-     * @param printStyle  the {@link PrintStyle} to be applied
+     * @param printStyle  the {@link PrintStyle}; if {@code null}, the default
+     *                    {@code PrintStyle} (defined by
+     *                    {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be
+     *                    applied
      *
      * @throws NullPointerException if the {@code PrintStream} is null
      * @since 2.4.0
@@ -624,9 +632,14 @@ public class Stopwatch
     }
 
     /**
-     * Returns a string containing a formatted stopwatch summary in default style.
+     * Returns a string containing a formatted output for this stopwatch in default style.
+     * <p>
+     * The default {@link PrintStyle} (defined by
+     * {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be applied.
+     * <p>
+     * For a custom {@code PrintStyle}, use {@link #toString(PrintStyle)}.
      *
-     * @return a string containing a stopwatch summary in default style
+     * @return a string containing a formatted output for this stopwatch in default style
      * @since 2.2.4
      */
     @Override
@@ -636,12 +649,18 @@ public class Stopwatch
     }
 
     /**
-     * Returns a string containing a formatted stopwatch summary in a custom
+     * Returns a string containing a formatted output for this stopwatch in a custom
      * {@link PrintStyle}.
+     * <p>
+     * The {@link PrintFormat} (whether to generate a summarized or detailed view) will be
+     * determined by the specified {@link PrintStyle}.
      *
-     * @param printStyle the {@link PrintStyle} to be applied; if {@code null}, the default
-     *                   {@code PrintStyle} will be applied
-     * @return a string containing stopwatch summary in the specified {@link PrintStyle}
+     * @param printStyle the {@link PrintStyle}; if {@code null}, the default
+     *                   {@code PrintStyle} (defined by
+     *                   {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be
+     *                   applied
+     * @return a string containing a formatted output for this stopwatch in the specified
+     *         {@link PrintStyle}
      * @since 2.4.0
      */
     public String toString(PrintStyle printStyle)

--- a/src/main/java/net/obvj/performetrics/config/Configuration.java
+++ b/src/main/java/net/obvj/performetrics/config/Configuration.java
@@ -36,18 +36,25 @@ public class Configuration
     /**
      * The initial time unit to be maintained if no specific time unit informed.
      */
-    protected static final TimeUnit INITIAL_TIME_UNIT = TimeUnit.NANOSECONDS;
+    static final TimeUnit INITIAL_TIME_UNIT = TimeUnit.NANOSECONDS;
 
     /**
      * The initial conversion mode to be applied if no specific mode is set.
      */
-    protected static final ConversionMode INITIAL_CONVERSION_MODE = ConversionMode.DOUBLE_PRECISION;
+    static final ConversionMode INITIAL_CONVERSION_MODE = ConversionMode.DOUBLE_PRECISION;
 
     /**
      * The initial maximum number of decimal places applicable if double-precision conversion
      * mode is set.
      */
-    protected static final int INITIAL_SCALE = 9;
+    static final int INITIAL_SCALE = 9;
+
+    /**
+     * The initial {@link PrintStyle} to be applied by default.
+     *
+     * @since 2.4.0
+     */
+    static final PrintStyle INITIAL_PRINT_STYLE = PrintStyle.SUMMARIZED_TABLE_FULL;
 
     /**
      * The initial {@link PrintStyle} to be applied by default for the summarized
@@ -55,7 +62,7 @@ public class Configuration
      *
      * @since 2.2.1
      */
-    protected static final PrintStyle INITIAL_PRINT_STYLE_FOR_SUMMARY = PrintStyle.SUMMARIZED_TABLE_FULL;
+    static final PrintStyle INITIAL_PRINT_STYLE_FOR_SUMMARY = PrintStyle.SUMMARIZED_TABLE_FULL;
 
     /**
      * The initial {@link PrintStyle} to be applied by default for the detailed
@@ -63,13 +70,14 @@ public class Configuration
      *
      * @since 2.2.1
      */
-    protected static final PrintStyle INITIAL_PRINT_STYLE_FOR_DETAILS = PrintStyle.DETAILED_TABLE_FULL;
+    static final PrintStyle INITIAL_PRINT_STYLE_FOR_DETAILS = PrintStyle.DETAILED_TABLE_FULL;
 
     private static final String MSG_PRINT_STYLE_MUST_NOT_BE_NULL = "The default PrintStyle must not be null";
 
     private TimeUnit timeUnit = INITIAL_TIME_UNIT;
     private ConversionMode conversionMode = INITIAL_CONVERSION_MODE;
     private int scale = INITIAL_SCALE;
+    private PrintStyle printStyle = INITIAL_PRINT_STYLE;
     private PrintStyle printStyleForSummary = INITIAL_PRINT_STYLE_FOR_SUMMARY;
     private PrintStyle printStyleForDetails = INITIAL_PRINT_STYLE_FOR_DETAILS;
 
@@ -145,6 +153,39 @@ public class Configuration
     }
 
     /**
+     * Returns the default {@link PrintStyle} to be applied when no style is specified.
+     *
+     * @return the default {@link PrintStyle} to be applied when no style is specified
+     * @since 2.4.0
+     */
+    public PrintStyle getPrintStyle()
+    {
+        return printStyle;
+    }
+
+    /**
+     * Defines the default {@link PrintStyle} to be applied when no style is specified.
+     * <p>
+     * The object will be applied by the following operations:
+     * </p>
+     * <ul>
+     * <li>{@link Stopwatch#print(java.io.PrintStream)}</li>
+     * <li>{@link Stopwatch#toString()}</li>
+     * <li>{@link MonitoredOperation#print(java.io.PrintStream)}</li>
+     * <li>{@link MonitoredOperation#toString()}</li>
+     * </ul>
+     *
+     * @param printStyle the {@link PrintStyle} to be set; not null
+     * @throws NullPointerException if the specified {@code PrintStyle} is null
+     *
+     * @since 2.4.0
+     */
+    public void setPrintStyle(PrintStyle printStyle)
+    {
+        this.printStyle = Objects.requireNonNull(printStyle, MSG_PRINT_STYLE_MUST_NOT_BE_NULL);
+    }
+
+    /**
      * Returns the default {@link PrintStyle} for the summarized stopwatch formatter.
      *
      * @return the default {@link PrintStyle} for the summarized stopwatch formatter
@@ -166,7 +207,7 @@ public class Configuration
      * </ul>
      *
      * @param printStyle the {@link PrintStyle} to be set; not null
-     * @throws NullPointerException if the specified PrintStyle is null
+     * @throws NullPointerException if the specified {@code PrintStyle} is null
      *
      * @since 2.2.1
      */
@@ -197,7 +238,7 @@ public class Configuration
      * </ul>
      *
      * @param printStyle the {@link PrintStyle} to be set; not null
-     * @throws NullPointerException if the specified PrintStyle is null
+     * @throws NullPointerException if the specified {@code PrintStyle} is null
      *
      * @since 2.2.1
      */

--- a/src/main/java/net/obvj/performetrics/monitors/MonitoredOperation.java
+++ b/src/main/java/net/obvj/performetrics/monitors/MonitoredOperation.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import net.obvj.performetrics.ConversionMode;
 import net.obvj.performetrics.Counter;
+import net.obvj.performetrics.Performetrics;
 import net.obvj.performetrics.Counter.Type;
 import net.obvj.performetrics.Stopwatch;
 import net.obvj.performetrics.util.Duration;
@@ -181,7 +182,12 @@ public abstract class MonitoredOperation
     }
 
     /**
-     * Prints elapsed times in the specified print stream with default summary style.
+     * Prints elapsed times in the specified print stream.
+     * <p>
+     * The default {@link PrintStyle} (defined by
+     * {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be applied.
+     * <p>
+     * For a custom {@code PrintStyle}, use {@link #print(PrintStream, PrintStyle)}.
      *
      * @param printStream the print stream to which data will be sent
      * @throws NullPointerException if the {@code PrintStream} is null
@@ -199,7 +205,10 @@ public abstract class MonitoredOperation
      * the specified {@link PrintStyle}.
      *
      * @param printStream the print stream to which data will be sent
-     * @param printStyle  the {@link PrintStyle} to be applied
+     * @param printStyle  the {@link PrintStyle}; if {@code null}, the default
+     *                    {@code PrintStyle} (defined by
+     *                    {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be
+     *                    applied
      *
      * @throws NullPointerException if the {@code PrintStream} is null
      * @since 2.4.0
@@ -295,9 +304,13 @@ public abstract class MonitoredOperation
     }
 
     /**
-     * Returns a string containing a formatted monitor summary.
+     * Returns a string containing a formatted output for this operation.
+     * <p>
+     * The default {@link PrintStyle} (defined by
+     * {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be applied.
+     * <p>
      *
-     * @return a string containing monitor summary
+     * @return a string containing formatted elapsed times for this opearation
      * @since 2.2.4
      */
     @Override

--- a/src/main/java/net/obvj/performetrics/monitors/MonitoredOperation.java
+++ b/src/main/java/net/obvj/performetrics/monitors/MonitoredOperation.java
@@ -181,11 +181,40 @@ public abstract class MonitoredOperation
     }
 
     /**
+     * Prints elapsed times in the specified print stream with default summary style.
+     *
+     * @param printStream the print stream to which data will be sent
+     * @throws NullPointerException if the {@code PrintStream} is null
+     * @since 2.4.0
+     */
+    public void print(PrintStream printStream)
+    {
+        PrintUtils.print(stopwatch, printStream);
+    }
+
+    /**
+     * Prints elapsed times in the specified print stream with a custom {@link PrintStyle}.
+     * <p>
+     * The format (whether to generate a summarized or detailed view) will be determined by
+     * the specified {@link PrintStyle}.
+     *
+     * @param printStream the print stream to which data will be sent
+     * @param printStyle  the {@link PrintStyle} to be applied
+     *
+     * @throws NullPointerException if the {@code PrintStream} is null
+     * @since 2.4.0
+     */
+    public void print(PrintStream printStream, PrintStyle printStyle)
+    {
+        PrintUtils.print(stopwatch, printStream, printStyle);
+    }
+
+    /**
      * Prints summarized elapsed times in the specified print stream.
      *
      * @param printStream the print stream to which data will be sent
      *
-     * @throws NullPointerException if the PrintStream is null
+     * @throws NullPointerException if the {@code PrintStream} is null
      *
      * @since 2.2.1
      */
@@ -201,9 +230,9 @@ public abstract class MonitoredOperation
      * @param printStream the print stream to which data will be sent
      * @param printStyle  the {@link PrintStyle} to be applied
      *
-     * @throws NullPointerException     if the PrintStream is null
-     * @throws IllegalArgumentException if the specified PrintStyle is not compatible with
-     *                                  {@link PrintFormat#SUMMARIZED}
+     * @throws NullPointerException     if the {@code PrintStream} is null
+     * @throws IllegalArgumentException if the specified {@code PrintStyle} is not compatible
+     *                                  with {@link PrintFormat#SUMMARIZED}
      * @since 2.2.1
      */
     public void printSummary(PrintStream printStream, PrintStyle printStyle)
@@ -232,9 +261,9 @@ public abstract class MonitoredOperation
      * @param printStream the print stream to which information will be sent
      * @param printStyle  the {@link PrintStyle} to be applied
      *
-     * @throws NullPointerException     if the PrintStream is null
-     * @throws IllegalArgumentException if the specified PrintStyle is not compatible with
-     *                                  {@link PrintFormat#DETAILED}
+     * @throws NullPointerException     if the {@code PrintStream} is null
+     * @throws IllegalArgumentException if the specified {@code PrintStyle} is not compatible
+     *                                  with {@link PrintFormat#DETAILED}
      * @since 2.2.1
      */
     public void printDetails(PrintStream printStream, PrintStyle printStyle)

--- a/src/main/java/net/obvj/performetrics/monitors/MonitoredOperation.java
+++ b/src/main/java/net/obvj/performetrics/monitors/MonitoredOperation.java
@@ -318,4 +318,24 @@ public abstract class MonitoredOperation
     {
         return stopwatch.toString();
     }
+
+    /**
+     * Returns a string containing a formatted output for this operation in a custom
+     * {@link PrintStyle}.
+     * <p>
+     * The {@link PrintFormat} (whether to generate a summarized or detailed view) will be
+     * determined by the specified {@link PrintStyle}.
+     *
+     * @param printStyle the {@link PrintStyle}; if {@code null}, the default
+     *                   {@code PrintStyle} (defined by
+     *                   {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be
+     *                   applied
+     * @return a string containing formatted elapsed times for this operation in the specified
+     *         {@link PrintStyle}
+     * @since 2.4.0
+     */
+    public String toString(PrintStyle printStyle)
+    {
+        return stopwatch.toString(printStyle);
+    }
 }

--- a/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintStyle.java
@@ -655,7 +655,7 @@ public class PrintStyle
      *
      * @param builder the {@link PrintStyleBuilder}
      */
-    protected PrintStyle(PrintStyleBuilder builder)
+    PrintStyle(PrintStyleBuilder builder)
     {
         printFormat = builder.getPrintFormat();
         printHeader = builder.isPrintHeader();
@@ -677,11 +677,24 @@ public class PrintStyle
     }
 
     /**
+     * Generates a string containing the formatted stopwatch output in this style.
+     *
+     * @param stopwatch the stopwatch to be printed; not null
+     * @return a string containing the formatted stopwatch output in this style
+     * @throws NullPointerException if the specified stopwatch is null
+     * @since 2.4.0
+     */
+    public String toString(Stopwatch stopwatch)
+    {
+        return printFormat.format(stopwatch, this);
+    }
+
+    /**
      * Returns the target {@code PrintFormat}.
      *
      * @return the target {@link PrintFormat}
      */
-    public PrintFormat getPrintFormat()
+    PrintFormat getPrintFormat()
     {
         return printFormat;
     }
@@ -691,7 +704,7 @@ public class PrintStyle
      *
      * @return the {@link DurationFormat} to be applied to all rows
      */
-    public DurationFormat getDurationFormat()
+    DurationFormat getDurationFormat()
     {
         return durationFormat;
     }
@@ -702,7 +715,7 @@ public class PrintStyle
      *
      * @return a flag indicating whether or not duration legends shall be printed
      */
-    public boolean isPrintLegend()
+    boolean isPrintLegend()
     {
         return printLegend;
     }
@@ -712,7 +725,7 @@ public class PrintStyle
      *
      * @return a flag indicating whether or not the header shall be printed
      */
-    public boolean isPrintHeader()
+    boolean isPrintHeader()
     {
         return printHeader;
     }
@@ -723,7 +736,7 @@ public class PrintStyle
      * @return a flag indicating whether or not the trailer shall be printed
      * @since 2.3.0
      */
-    public boolean isPrintTrailer()
+    boolean isPrintTrailer()
     {
         return printTrailer;
     }
@@ -734,7 +747,7 @@ public class PrintStyle
      *
      * @return a flag indicating whether or not the section summary shall be printed
      */
-    public boolean isPrintSectionSummary()
+    boolean isPrintSectionSummary()
     {
         return printSectionSummary;
     }
@@ -746,7 +759,7 @@ public class PrintStyle
      * @return a flag indicating whether or not the section trailer shall be printed
      * @since 2.3.0
      */
-    public boolean isPrintSectionTrailer()
+    boolean isPrintSectionTrailer()
     {
         return printSectionTrailer;
     }
@@ -756,7 +769,7 @@ public class PrintStyle
      *
      * @return the string format to be applied to the header
      */
-    public String getHeaderFormat()
+    String getHeaderFormat()
     {
         return headerFormat;
     }
@@ -767,7 +780,7 @@ public class PrintStyle
      * @return the string format to be applied to the trailer
      * @since 2.3.0
      */
-    public String getTrailerFormat()
+    String getTrailerFormat()
     {
         return trailerFormat;
     }
@@ -777,7 +790,7 @@ public class PrintStyle
      *
      * @return the format to be applied to all rows in general
      */
-    public String getRowFormat()
+    String getRowFormat()
     {
         return rowFormat;
     }
@@ -787,7 +800,7 @@ public class PrintStyle
      *
      * @return the format to be applied to each section header
      */
-    public String getSectionHeaderFormat()
+    String getSectionHeaderFormat()
     {
         return sectionHeaderFormat;
     }
@@ -797,7 +810,7 @@ public class PrintStyle
      *
      * @return the format to be applied to the total/summary row(s)
      */
-    public String getSectionSummaryRowFormat()
+    String getSectionSummaryRowFormat()
     {
         return sectionSummaryRowFormat;
     }
@@ -808,7 +821,7 @@ public class PrintStyle
      * @return the format to be applied to the section trailer row(s)
      * @since 2.3.0
      */
-    public String getSectionTrailerFormat()
+    String getSectionTrailerFormat()
     {
         return sectionTrailerFormat;
     }
@@ -818,7 +831,7 @@ public class PrintStyle
      *
      * @return a string to be used as simple split line
      */
-    public String getSimpleLine()
+    String getSimpleLine()
     {
         return simpleLine;
     }
@@ -828,7 +841,7 @@ public class PrintStyle
      *
      * @return a string to be used as alternative split line
      */
-    public String getAlternativeLine()
+    String getAlternativeLine()
     {
         return alternativeLine;
     }
@@ -839,7 +852,7 @@ public class PrintStyle
      * @return a collection of types to be excluded
      * @since 2.4.0
      */
-    public Collection<Type> getExcludedTypes()
+    Collection<Type> getExcludedTypes()
     {
         return excludedTypes;
     }
@@ -852,7 +865,7 @@ public class PrintStyle
      * @return a flag indicating whether the specified {@link Type} is to be printed
      * @since 2.4.0
      */
-    public boolean isPrintable(Type type)
+    boolean isPrintable(Type type)
     {
         return !excludedTypes.contains(type);
     }
@@ -862,7 +875,7 @@ public class PrintStyle
      *
      * @since 2.4.0
      */
-    public Map<Type, String> getCustomCounterNames()
+    Map<Type, String> getCustomCounterNames()
     {
         return customCounterNames;
     }
@@ -875,7 +888,7 @@ public class PrintStyle
      * @return the counter name to be printed
      * @since 2.4.0
      */
-    public String getPrintableCounterName(Type type)
+    String getPrintableCounterName(Type type)
     {
         return customCounterNames.getOrDefault(type, type.toString());
     }

--- a/src/main/java/net/obvj/performetrics/util/print/PrintUtils.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintUtils.java
@@ -18,6 +18,7 @@ package net.obvj.performetrics.util.print;
 
 import java.io.PrintStream;
 
+import net.obvj.performetrics.Performetrics;
 import net.obvj.performetrics.Stopwatch;
 import net.obvj.performetrics.config.ConfigurationHolder;
 
@@ -40,7 +41,8 @@ public class PrintUtils
     /**
      * Prints summarized elapsed times from the given stopwatch in the specified print stream.
      * <p>
-     * The default {@link PrintStyle} will be applied.
+     * The default {@link PrintStyle} (defined by
+     * {@link Performetrics#setDefaultPrintStyleForSummary(PrintStyle)}) will be applied.
      *
      * @param stopwatch   the stopwatch to be printed
      * @param printStream the print stream to which data will be sent
@@ -60,8 +62,10 @@ public class PrintUtils
      *
      * @param stopwatch   the stopwatch to be printed
      * @param printStream the print stream to which data will be sent
-     * @param printStyle  the {@link PrintStyle} to be applied; if {@code null}, the default
-     *                    PrintStyle will be applied
+     * @param printStyle  the {@link PrintStyle}; if {@code null}, the default
+     *                    {@code PrintStyle} (defined by
+     *                    {@link Performetrics#setDefaultPrintStyleForSummary(PrintStyle)})
+     *                    will be applied
      *
      * @throws NullPointerException     if a null stopwatch or print stream is received
      * @throws IllegalArgumentException if the specified PrintStyle is not compatible with
@@ -80,7 +84,8 @@ public class PrintUtils
      * Prints detailed information about timing sessions from the given stopwatch in the
      * specified print stream.
      * <p>
-     * The default {@link PrintStyle} will be applied.
+     * The default {@link PrintStyle} (defined by
+     * {@link Performetrics#setDefaultPrintStyleForDetails(PrintStyle)}) will be applied.
      *
      * @param stopwatch   the stopwatch to be printed
      * @param printStream the print stream to which information will be sent
@@ -100,8 +105,10 @@ public class PrintUtils
      *
      * @param stopwatch   the stopwatch to be printed
      * @param printStream the print stream to which information will be sent
-     * @param printStyle  the {@link PrintStyle} to be applied; if {@code null}, the default
-     *                    PrintStyle will be applied
+     * @param printStyle  the {@link PrintStyle}; if {@code null}, the default
+     *                    {@code PrintStyle} (defined by
+     *                    {@link Performetrics#setDefaultPrintStyleForDetails(PrintStyle)})
+     *                    will be applied
      *
      * @throws NullPointerException     if a null stopwatch or print stream is received
      * @throws IllegalArgumentException if the specified PrintStyle is not compatible with
@@ -154,7 +161,8 @@ public class PrintUtils
     /**
      * Prints elapsed times from the given stopwatch in the specified print stream.
      * <p>
-     * The default {@link PrintStyle} for summarized view will be applied.
+     * The default {@link PrintStyle} (defined by
+     * {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be applied.
      *
      * @param stopwatch   the stopwatch to be printed
      * @param printStream the print stream to which data will be sent
@@ -176,11 +184,12 @@ public class PrintUtils
      *
      * @param stopwatch   the stopwatch to be printed; not null
      * @param printStream the print stream to which data will be sent; not null
-     * @param printStyle  the {@link PrintStyle} to be applied; if {@code null}, the default
-     *                    {@code PrintStyle} for summarized view will be applied
+     * @param printStyle  the {@link PrintStyle}; if {@code null}, the default
+     *                    {@code PrintStyle} (defined by
+     *                    {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be
+     *                    applied
      *
      * @throws NullPointerException if a null stopwatch or print stream is received
-     *
      * @since 2.4.0
      */
     public static void print(Stopwatch stopwatch, PrintStream printStream, PrintStyle printStyle)
@@ -191,9 +200,12 @@ public class PrintUtils
     /**
      * Returns a string containing a formatted summary from the given stopwatch in default
      * style.
+     * <p>
+     * The default {@link PrintStyle} (defined by
+     * {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be applied.
      *
      * @param stopwatch to stopwatch to be used; not null
-     * @return string containing a formatted summary from the given stopwatch
+     * @return string containing a formatted output from the given stopwatch
      *
      * @since 2.4.0
      */
@@ -210,8 +222,10 @@ public class PrintUtils
      * determined by the specified {@link PrintStyle}.
      *
      * @param stopwatch  to stopwatch to be used
-     * @param printStyle the {@link PrintStyle} to be applied; if {@code null}, the default
-     *                   {@code PrintStyle} for summarized view will be applied
+     * @param printStyle the {@link PrintStyle}; if {@code null}, the default
+     *                   {@code PrintStyle} (defined by
+     *                   {@link Performetrics#setDefaultPrintStyle(PrintStyle)}) will be
+     *                   applied
      * @return string containing a formatted output from the given stopwatch
      *
      * @since 2.4.0
@@ -219,7 +233,7 @@ public class PrintUtils
     public static String toString(Stopwatch stopwatch, PrintStyle printStyle)
     {
         PrintStyle style = printStyle != null ? printStyle
-                : ConfigurationHolder.getConfiguration().getPrintStyleForSummary();
+                : ConfigurationHolder.getConfiguration().getPrintStyle();
         return style.toString(stopwatch);
     }
 

--- a/src/main/java/net/obvj/performetrics/util/print/PrintUtils.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintUtils.java
@@ -71,7 +71,9 @@ public class PrintUtils
      */
     public static void printSummary(Stopwatch stopwatch, PrintStream printStream, PrintStyle printStyle)
     {
-        printStream.print(summaryToString(stopwatch, printStyle));
+        PrintStyle style = printStyle != null ? printStyle
+                : ConfigurationHolder.getConfiguration().getPrintStyleForSummary();
+        printStream.print(PrintFormat.SUMMARIZED.format(stopwatch, style));
     }
 
     /**
@@ -121,7 +123,9 @@ public class PrintUtils
      * @return string containing a formatted summary from the given stopwatch
      *
      * @since 2.2.4
+     * @deprecated Use {@link PrintUtils#toString(Stopwatch)} instead.
      */
+    @Deprecated
     public static String summaryToString(Stopwatch stopwatch)
     {
         return summaryToString(stopwatch, null);
@@ -133,16 +137,90 @@ public class PrintUtils
      *
      * @param stopwatch  to stopwatch to be used
      * @param printStyle the {@link PrintStyle} to be applied; if {@code null}, the default
-     *                   PrintStyle will be applied
+     *                   {@code PrintStyle} will be applied
      * @return string containing a formatted summary from the given stopwatch
      *
      * @since 2.2.4
+     * @deprecated Use {@link PrintUtils#toString(Stopwatch, PrintStyle)} instead.
      */
+    @Deprecated
     public static String summaryToString(Stopwatch stopwatch, PrintStyle printStyle)
     {
         PrintStyle style = printStyle != null ? printStyle
                 : ConfigurationHolder.getConfiguration().getPrintStyleForSummary();
         return PrintFormat.SUMMARIZED.format(stopwatch, style);
+    }
+
+    /**
+     * Prints elapsed times from the given stopwatch in the specified print stream.
+     * <p>
+     * The default {@link PrintStyle} for summarized view will be applied.
+     *
+     * @param stopwatch   the stopwatch to be printed
+     * @param printStream the print stream to which data will be sent
+     *
+     * @throws NullPointerException if a null stopwatch or print stream is received
+     * @since 2.4.0
+     */
+    public static void print(Stopwatch stopwatch, PrintStream printStream)
+    {
+        print(stopwatch, printStream, null);
+    }
+
+    /**
+     * Prints elapsed times from the given stopwatch in the specified print stream, with a
+     * custom {@link PrintStyle}.
+     * <p>
+     * The {@link PrintFormat} (whether to generate a summarized or detailed view) will be
+     * determined by the specified {@link PrintStyle}.
+     *
+     * @param stopwatch   the stopwatch to be printed; not null
+     * @param printStream the print stream to which data will be sent; not null
+     * @param printStyle  the {@link PrintStyle} to be applied; if {@code null}, the default
+     *                    {@cpde PrintStyle} for summarized view will be applied
+     *
+     * @throws NullPointerException if a null stopwatch or print stream is received
+     *
+     * @since 2.4.0
+     */
+    public static void print(Stopwatch stopwatch, PrintStream printStream, PrintStyle printStyle)
+    {
+        printStream.print(toString(stopwatch, printStyle));
+    }
+
+    /**
+     * Returns a string containing a formatted summary from the given stopwatch in default
+     * style.
+     *
+     * @param stopwatch to stopwatch to be used; not null
+     * @return string containing a formatted summary from the given stopwatch
+     *
+     * @since 2.4.0
+     */
+    public static String toString(Stopwatch stopwatch)
+    {
+        return toString(stopwatch, null);
+    }
+
+    /**
+     * Returns a string containing a formatted output from the given stopwatch in a custom
+     * {@link PrintStyle}.
+     * <p>
+     * The {@link PrintFormat} (whether to generate a summarized or detailed view) will be
+     * determined by the specified {@link PrintStyle}.
+     *
+     * @param stopwatch  to stopwatch to be used
+     * @param printStyle the {@link PrintStyle} to be applied; if {@code null}, the default
+     *                   {@code PrintStyle} for summarized view will be applied
+     * @return string containing a formatted output from the given stopwatch
+     *
+     * @since 2.4.0
+     */
+    public static String toString(Stopwatch stopwatch, PrintStyle printStyle)
+    {
+        PrintStyle style = printStyle != null ? printStyle
+                : ConfigurationHolder.getConfiguration().getPrintStyleForSummary();
+        return style.toString(stopwatch);
     }
 
 }

--- a/src/main/java/net/obvj/performetrics/util/print/PrintUtils.java
+++ b/src/main/java/net/obvj/performetrics/util/print/PrintUtils.java
@@ -177,7 +177,7 @@ public class PrintUtils
      * @param stopwatch   the stopwatch to be printed; not null
      * @param printStream the print stream to which data will be sent; not null
      * @param printStyle  the {@link PrintStyle} to be applied; if {@code null}, the default
-     *                    {@cpde PrintStyle} for summarized view will be applied
+     *                    {@code PrintStyle} for summarized view will be applied
      *
      * @throws NullPointerException if a null stopwatch or print stream is received
      *

--- a/src/test/java/net/obvj/performetrics/PerformetricsTest.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTest.java
@@ -54,6 +54,7 @@ class PerformetricsTest
     private static final TimeUnit INITIAL_TIME_UNIT = ConfigurationHolder.getConfiguration().getTimeUnit();
     private static final ConversionMode INITIAL_CONVERSION_MODE = ConfigurationHolder.getConfiguration().getConversionMode();
     private static final int INITIAL_SCALE = ConfigurationHolder.getConfiguration().getScale();
+    private static final PrintStyle INITIAL_PRINT_STYLE = ConfigurationHolder.getConfiguration().getPrintStyle();
     private static final PrintStyle INITIAL_PRINT_STYLE_FOR_SUMMARY = ConfigurationHolder.getConfiguration().getPrintStyleForSummary();
     private static final PrintStyle INITIAL_PRINT_STYLE_FOR_DETAILS = ConfigurationHolder.getConfiguration().getPrintStyleForDetails();
 
@@ -77,6 +78,7 @@ class PerformetricsTest
         checkDefaultTimeUnit();
         checkDefaultConversionMode();
         checkDefaulScale();
+        checkDefaulPrintStyle();
         checkDefaulPrintStyleForSummary();
         checkDefaulPrintStyleForDetails();
     }
@@ -94,6 +96,12 @@ class PerformetricsTest
     private void checkDefaulScale()
     {
         assertThat(ConfigurationHolder.getConfiguration().getScale(), is(equalTo(INITIAL_SCALE)));
+    }
+
+    private void checkDefaulPrintStyle()
+    {
+        assertThat(ConfigurationHolder.getConfiguration().getPrintStyle(),
+                is(equalTo(INITIAL_PRINT_STYLE)));
     }
 
     private void checkDefaulPrintStyleForSummary()
@@ -208,6 +216,32 @@ class PerformetricsTest
     }
 
     @Test
+    void setDefaultPrintStyle_valid_updatesConfiguration()
+    {
+        PrintStyle ps = mock(PrintStyle.class);
+        Performetrics.setDefaultPrintStyle(ps);
+        assertThat(ConfigurationHolder.getConfiguration().getPrintStyle(), is(equalTo(ps)));
+        checkDefaultConversionMode();
+        checkDefaultTimeUnit();
+        checkDefaulScale();
+        checkDefaulPrintStyleForSummary();
+        checkDefaulPrintStyleForDetails();
+    }
+
+    @Test
+    void setDefaultPrintStyle_null_doesNotUpdateConfiguration()
+    {
+        try
+        {
+            Performetrics.setDefaultPrintStyleForSummary(null);
+        }
+        catch (NullPointerException e)
+        {
+            checkAllDefaultValues();
+        }
+    }
+
+    @Test
     void setDefaultPrintStyleForSummary_valid_updatesConfiguration()
     {
         PrintStyle ps = mock(PrintStyle.class);
@@ -216,6 +250,7 @@ class PerformetricsTest
         checkDefaultConversionMode();
         checkDefaultTimeUnit();
         checkDefaulScale();
+        checkDefaulPrintStyle();
         checkDefaulPrintStyleForDetails();
     }
 
@@ -241,6 +276,7 @@ class PerformetricsTest
         checkDefaultConversionMode();
         checkDefaultTimeUnit();
         checkDefaulScale();
+        checkDefaulPrintStyle();
         checkDefaulPrintStyleForSummary();
     }
 

--- a/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
@@ -16,6 +16,9 @@
 
 package net.obvj.performetrics;
 
+import static java.util.concurrent.TimeUnit.*;
+import static net.obvj.performetrics.Counter.Type.*;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.math.BigInteger;
@@ -26,10 +29,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import net.obvj.performetrics.Counter.Type;
 import net.obvj.performetrics.monitors.MonitoredCallable;
 import net.obvj.performetrics.util.DurationFormat;
 import net.obvj.performetrics.util.print.PrintStyle;
@@ -82,22 +83,22 @@ public class PerformetricsTestDrive
 
         sw.stop();
 
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME));
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.NANOSECONDS) + " nanoseconds");
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.NANOSECONDS) + " nanoseconds");
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.MILLISECONDS) + " milliseconds");
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.MILLISECONDS) + " milliseconds");
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.SECONDS) + " seconds");
-        System.out.println(sw.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.SECONDS) + " seconds");
+        System.out.println(sw.elapsedTime(WALL_CLOCK_TIME));
+        System.out.println(sw.elapsedTime(WALL_CLOCK_TIME, NANOSECONDS) + " nanoseconds");
+        System.out.println(sw.elapsedTime(WALL_CLOCK_TIME).toTimeUnit(NANOSECONDS) + " nanoseconds");
+        System.out.println(sw.elapsedTime(WALL_CLOCK_TIME, MILLISECONDS) + " milliseconds");
+        System.out.println(sw.elapsedTime(WALL_CLOCK_TIME).toTimeUnit(MILLISECONDS) + " milliseconds");
+        System.out.println(sw.elapsedTime(WALL_CLOCK_TIME, SECONDS) + " seconds");
+        System.out.println(sw.elapsedTime(WALL_CLOCK_TIME).toTimeUnit(SECONDS) + " seconds");
 
         System.out.println();
-        sw.printSummary(System.out, PrintStyle.LINUX);
+        sw.print(System.out, PrintStyle.LINUX);
         System.out.println();
         sw.printDetails(System.out);
 
         System.out.println("\nSESSION CHECK:");
-        System.out.println(" - Last elapsed time (WALL_CLOCK_TIME): " + sw.lastSession().elapsedTime(Type.WALL_CLOCK_TIME).toString(DurationFormat.LINUX));
-        System.out.println(" - Last elapsed time (CPU_TIME): "        + sw.lastSession().elapsedTime(Type.CPU_TIME).toString(DurationFormat.LINUX));
+        System.out.println(" - Last elapsed time (WALL_CLOCK_TIME): " + sw.lastSession().elapsedTime(WALL_CLOCK_TIME).toString(DurationFormat.LINUX));
+        System.out.println(" - Last elapsed time (CPU_TIME): "        + sw.lastSession().elapsedTime(CPU_TIME).toString(DurationFormat.LINUX));
         System.out.println();
     }
 
@@ -121,16 +122,16 @@ public class PerformetricsTestDrive
     {
         System.out.println(operation.call());
 
-        System.out.println(operation.elapsedTime(Type.WALL_CLOCK_TIME));
-        System.out.println(operation.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.NANOSECONDS) + " nanosecods");
-        System.out.println(operation.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.NANOSECONDS) + " nanosecods");
-        System.out.println(operation.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.MILLISECONDS) + " millisecods");
-        System.out.println(operation.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.MILLISECONDS) + " millisecods");
-        System.out.println(operation.elapsedTime(Type.WALL_CLOCK_TIME, TimeUnit.SECONDS) + " seconds");
-        System.out.println(operation.elapsedTime(Type.WALL_CLOCK_TIME).toTimeUnit(TimeUnit.SECONDS) + " seconds");
+        System.out.println(operation.elapsedTime(WALL_CLOCK_TIME));
+        System.out.println(operation.elapsedTime(WALL_CLOCK_TIME, NANOSECONDS) + " nanosecods");
+        System.out.println(operation.elapsedTime(WALL_CLOCK_TIME).toTimeUnit(NANOSECONDS) + " nanosecods");
+        System.out.println(operation.elapsedTime(WALL_CLOCK_TIME, MILLISECONDS) + " millisecods");
+        System.out.println(operation.elapsedTime(WALL_CLOCK_TIME).toTimeUnit(MILLISECONDS) + " millisecods");
+        System.out.println(operation.elapsedTime(WALL_CLOCK_TIME, SECONDS) + " seconds");
+        System.out.println(operation.elapsedTime(WALL_CLOCK_TIME).toTimeUnit(SECONDS) + " seconds");
 
-        operation.printSummary(System.out);
         System.out.println();
+        operation.print(System.out, PrintStyle.LINUX);
 
         operation.printDetails(new PrintStream("stopwatch.csv"), PrintStyle.DETAILED_CSV);
         System.out.println();

--- a/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
@@ -131,7 +131,9 @@ public class PerformetricsTestDrive
         System.out.println(operation.elapsedTime(WALL_CLOCK_TIME).toTimeUnit(SECONDS) + " seconds");
 
         System.out.println();
-        operation.print(System.out, PrintStyle.LINUX);
+        operation.print(System.out, PrintStyle.SUMMARIZED_XML);
+        System.out.println("*****");
+        operation.print(System.out, PrintStyle.DETAILED_XML);
 
         operation.printDetails(new PrintStream("stopwatch.csv"), PrintStyle.DETAILED_CSV);
         System.out.println();

--- a/src/test/java/net/obvj/performetrics/StopwatchTest.java
+++ b/src/test/java/net/obvj/performetrics/StopwatchTest.java
@@ -734,7 +734,7 @@ class StopwatchTest
         try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
         {
             sw.toString();
-            printUtils.verify(() -> PrintUtils.summaryToString(sw), times(1));
+            printUtils.verify(() -> PrintUtils.toString(sw), times(1));
         }
     }
 

--- a/src/test/java/net/obvj/performetrics/StopwatchTest.java
+++ b/src/test/java/net/obvj/performetrics/StopwatchTest.java
@@ -301,6 +301,29 @@ class StopwatchTest
     }
 
     @Test
+    void print_withPrintWriterArgument_callsCorrectPrintUtilMethod()
+    {
+        Stopwatch sw = new Stopwatch();
+        try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
+        {
+            sw.print(System.out);
+            printUtils.verify(() -> PrintUtils.print(sw, System.out), times(1));
+        }
+    }
+
+    @Test
+    void print_withPrintWriterAndPrintStyle_callsCorrectPrintUtilMethod()
+    {
+        PrintStyle ps = mock(PrintStyle.class);
+        Stopwatch sw = new Stopwatch();
+        try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
+        {
+            sw.print(System.out, ps);
+            printUtils.verify(() -> PrintUtils.print(sw, System.out, ps), times(1));
+        }
+    }
+
+    @Test
     void printSummary_withPrintWriterArgument_callsCorrectPrintUtilMethod()
     {
         Stopwatch sw = new Stopwatch();
@@ -735,6 +758,18 @@ class StopwatchTest
         {
             sw.toString();
             printUtils.verify(() -> PrintUtils.toString(sw), times(1));
+        }
+    }
+
+    @Test
+    void toString_customPrintStyle_callsCorrectPrintUtilMethod()
+    {
+        PrintStyle ps = mock(PrintStyle.class);
+        Stopwatch sw = new Stopwatch();
+        try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
+        {
+            sw.toString(ps);
+            printUtils.verify(() -> PrintUtils.toString(sw, ps), times(1));
         }
     }
 

--- a/src/test/java/net/obvj/performetrics/monitors/MonitoredCallableTest.java
+++ b/src/test/java/net/obvj/performetrics/monitors/MonitoredCallableTest.java
@@ -136,6 +136,17 @@ class MonitoredCallableTest
     }
 
     @Test
+    void print_withPrintWriterArgument_callsCorrectPrintUtilMethod()
+    {
+        MonitoredCallable<String> operation = new MonitoredCallable<>(callable);
+        try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
+        {
+            operation.print(System.out);
+            printUtils.verify(() -> PrintUtils.print(operation.stopwatch, System.out), times(1));
+        }
+    }
+
+    @Test
     void printSummary_withPrintWriterArgument_callsCorrectPrintUtilMethod()
     {
         MonitoredCallable<String> operation = new MonitoredCallable<>(callable);

--- a/src/test/java/net/obvj/performetrics/monitors/MonitoredRunnableTest.java
+++ b/src/test/java/net/obvj/performetrics/monitors/MonitoredRunnableTest.java
@@ -154,6 +154,29 @@ class MonitoredRunnableTest
     }
 
     @Test
+    void print_withPrintWriterArgument_callsCorrectPrintUtilMethod()
+    {
+        MonitoredRunnable operation = new MonitoredRunnable(runnable);
+        try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
+        {
+            operation.print(System.out);
+            printUtils.verify(() -> PrintUtils.print(operation.stopwatch, System.out), times(1));
+        }
+    }
+
+    @Test
+    void print_withPrintWriterAndPrintStyle_callsCorrectPrintUtilMethod()
+    {
+        PrintStyle ps = mock(PrintStyle.class);
+        MonitoredRunnable operation = new MonitoredRunnable(runnable);
+        try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
+        {
+            operation.print(System.out, ps);
+            printUtils.verify(() -> PrintUtils.print(operation.stopwatch, System.out, ps), times(1));
+        }
+    }
+
+    @Test
     void printSummary_withPrintWriterArgument_callsCorrectPrintUtilMethod()
     {
         MonitoredRunnable operation = new MonitoredRunnable(runnable);
@@ -281,8 +304,24 @@ class MonitoredRunnableTest
     @Test
     void toString_callsCorrectPrintUtilMethod()
     {
-        MonitoredRunnable operation = newMonitoredRunnableWithMockedStopwatch();
-        assertThat(operation.toString(), equalTo(stopwatch.toString()));
+        MonitoredRunnable operation = new MonitoredRunnable(runnable);
+        try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
+        {
+            operation.toString();
+            printUtils.verify(() -> PrintUtils.toString(operation.stopwatch), times(1));
+        }
+    }
+
+    @Test
+    void toString_customPrintStyle_callsCorrectPrintUtilMethod()
+    {
+        PrintStyle ps = mock(PrintStyle.class);
+        MonitoredRunnable operation = new MonitoredRunnable(runnable);
+        try (MockedStatic<PrintUtils> printUtils = mockStatic(PrintUtils.class))
+        {
+            operation.toString(ps);
+            printUtils.verify(() -> PrintUtils.toString(operation.stopwatch, ps), times(1));
+        }
     }
 
 }

--- a/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
@@ -155,7 +155,7 @@ class PrintUtilsTest
     }
 
     @Test
-    void print_withStopwatchAndPrintStreamAndPrintStyle_printsToTheStream()
+    void print_withStopwatchAndPrintStreamAndSummarizedPrintStyle_printsToTheStream()
             throws UnsupportedEncodingException
     {
         String expectedString = PrintFormat.SUMMARIZED.format(stopwatch, PrintStyle.SUMMARIZED_CSV);
@@ -163,6 +163,20 @@ class PrintUtilsTest
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream printStream = new PrintStream(baos, true, "UTF-8");
         PrintUtils.print(stopwatch, printStream, PrintStyle.SUMMARIZED_CSV);
+        String printedString = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        assertThat(printedString, is(equalTo(expectedString)));
+    }
+
+    @Test
+    void print_withStopwatchAndPrintStreamAndDetailedPrintStyle_printsToTheStream()
+            throws UnsupportedEncodingException
+    {
+        String expectedString = PrintFormat.DETAILED.format(stopwatch, PrintStyle.DETAILED_CSV);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(baos, true, "UTF-8");
+        PrintUtils.print(stopwatch, printStream, PrintStyle.DETAILED_CSV);
         String printedString = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
         assertThat(printedString, is(equalTo(expectedString)));

--- a/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
@@ -190,7 +190,7 @@ class PrintUtilsTest
     {
         String expectedString = PrintFormat.SUMMARIZED.format(stopwatch,
                 ConfigurationHolder.getConfiguration().getPrintStyleForSummary());
-        String actualString = PrintUtils.summaryToString(stopwatch);
+        String actualString = PrintUtils.toString(stopwatch);
         assertThat(actualString, is(equalTo(expectedString)));
     }
 
@@ -198,7 +198,7 @@ class PrintUtilsTest
     void summaryToString_withStopwatchAndPrintStyle_validString()
     {
         String expectedString = PrintFormat.SUMMARIZED.format(stopwatch, PrintStyle.SUMMARIZED_CSV);
-        String actualString = PrintUtils.summaryToString(stopwatch, PrintStyle.SUMMARIZED_CSV);
+        String actualString = PrintUtils.toString(stopwatch, PrintStyle.SUMMARIZED_CSV);
         assertThat(actualString, is(equalTo(expectedString)));
     }
 }

--- a/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.Test;
 
 import net.obvj.performetrics.Counter;
 import net.obvj.performetrics.Counter.Type;
+import net.obvj.performetrics.Performetrics;
 import net.obvj.performetrics.Stopwatch;
 import net.obvj.performetrics.config.ConfigurationHolder;
 import net.obvj.performetrics.util.DurationFormat;
@@ -56,11 +58,15 @@ class PrintUtilsTest
     private static final Counter C1 = newCounter(WALL_CLOCK_TIME, MILLISECONDS, 5000, 6000);
     private static final Counter C2 = newCounter(CPU_TIME, NANOSECONDS, 700000000000l, 900000000000l);
     private static final Map<Type, List<Counter>> ALL_COUNTERS = new EnumMap<>(Type.class);
+    private static final List<Type> ALL_TYPES = Arrays.asList(WALL_CLOCK_TIME, CPU_TIME);
+
+    private static final PrintStyle DEFAULT_PRINT_STYLE = PrintStyle.SUMMARIZED_XML;
 
     static
     {
         ALL_COUNTERS.put(WALL_CLOCK_TIME, singletonList(C1));
         ALL_COUNTERS.put(CPU_TIME, singletonList(C2));
+        Performetrics.setDefaultPrintStyle(DEFAULT_PRINT_STYLE);
     }
 
     Stopwatch stopwatch = mock(Stopwatch.class);
@@ -70,6 +76,9 @@ class PrintUtilsTest
     void setup()
     {
         when(stopwatch.getAllCountersByType()).thenReturn(ALL_COUNTERS);
+        when(stopwatch.getTypes()).thenReturn(ALL_TYPES);
+        when(stopwatch.elapsedTime(WALL_CLOCK_TIME)).thenReturn(C1.elapsedTime());
+        when(stopwatch.elapsedTime(CPU_TIME)).thenReturn(C2.elapsedTime());
     }
 
     private static Counter newCounter(Type type, TimeUnit timeUnit, long unitsBefore, long unitsAfter)
@@ -87,6 +96,23 @@ class PrintUtilsTest
     void constructor_instantiationNotAllowed()
     {
         assertThat(PrintUtils.class, instantiationNotAllowed().throwing(IllegalStateException.class));
+    }
+
+    /**
+     * Test stopwatch printing onto a PrintStream.
+     */
+    @Test
+    void print_withStopwatchAndPrintStream_printsTableToTheStream()
+            throws UnsupportedEncodingException
+    {
+        String expectedString = PrintFormat.SUMMARIZED.format(stopwatch, DEFAULT_PRINT_STYLE);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos, true, "UTF-8");
+        PrintUtils.print(stopwatch, ps);
+        String printedString = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        assertThat(printedString, is(equalTo(expectedString)));
     }
 
     /**
@@ -126,6 +152,20 @@ class PrintUtilsTest
         when(printStyle.getPrintFormat()).thenReturn(printFormat);
         when(printStyle.getDurationFormat()).thenReturn(DurationFormat.FULL);
         when(printStyle.getRowFormat()).thenReturn("%s");
+    }
+
+    @Test
+    void print_withStopwatchAndPrintStreamAndPrintStyle_printsToTheStream()
+            throws UnsupportedEncodingException
+    {
+        String expectedString = PrintFormat.SUMMARIZED.format(stopwatch, PrintStyle.SUMMARIZED_CSV);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(baos, true, "UTF-8");
+        PrintUtils.print(stopwatch, printStream, PrintStyle.SUMMARIZED_CSV);
+        String printedString = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        assertThat(printedString, is(equalTo(expectedString)));
     }
 
     @Test
@@ -190,12 +230,29 @@ class PrintUtilsTest
     {
         String expectedString = PrintFormat.SUMMARIZED.format(stopwatch,
                 ConfigurationHolder.getConfiguration().getPrintStyleForSummary());
-        String actualString = PrintUtils.toString(stopwatch);
+        String actualString = PrintUtils.summaryToString(stopwatch);
         assertThat(actualString, is(equalTo(expectedString)));
     }
 
     @Test
     void summaryToString_withStopwatchAndPrintStyle_validString()
+    {
+        String expectedString = PrintFormat.SUMMARIZED.format(stopwatch, PrintStyle.SUMMARIZED_CSV);
+        String actualString = PrintUtils.summaryToString(stopwatch, PrintStyle.SUMMARIZED_CSV);
+        assertThat(actualString, is(equalTo(expectedString)));
+    }
+
+    @Test
+    void toString_withStopwatch_validString()
+    {
+        String expectedString = PrintFormat.SUMMARIZED.format(stopwatch,
+                ConfigurationHolder.getConfiguration().getPrintStyle());
+        String actualString = PrintUtils.toString(stopwatch);
+        assertThat(actualString, is(equalTo(expectedString)));
+    }
+
+    @Test
+    void toString_withStopwatchAndPrintStyle_validString()
     {
         String expectedString = PrintFormat.SUMMARIZED.format(stopwatch, PrintStyle.SUMMARIZED_CSV);
         String actualString = PrintUtils.toString(stopwatch, PrintStyle.SUMMARIZED_CSV);


### PR DESCRIPTION
Add new methods for printing elapsed times that determine the format automatically based on the `PrintStyle`:
- `Stopwatch.print(PrintStream)`
- `Stopwatch.print(PrintStream, PrintStyle)`
- `MonitoredOperation.print(PrintStream)`
- `MonitoredOperation.print(PrintStream, PrintStyle)`