### PR TITLE
Introduce new UnmodifiableCounter class

### DIFF
--- a/src/main/java/net/obvj/performetrics/Counter.java
+++ b/src/main/java/net/obvj/performetrics/Counter.java
@@ -299,7 +299,7 @@ public class Counter
      *         units are set; or the difference between {@code unitsBefore} and the current
      *         value retrieved by the counter's time source, if {@code unitsAfter} is not set
      */
-    long elapsedTimeInternal()
+    private long elapsedTimeInternal()
     {
         long tempUnitsAfter = unitsAfterSet ? unitsAfter : type.getTime(timeUnit);
         return tempUnitsAfter >= unitsBefore ? tempUnitsAfter - unitsBefore : -1;

--- a/src/main/java/net/obvj/performetrics/UnmodifiableCounter.java
+++ b/src/main/java/net/obvj/performetrics/UnmodifiableCounter.java
@@ -35,10 +35,10 @@ public final class UnmodifiableCounter extends Counter
     private final Counter counter;
 
     /**
-     * Builds a Counter with a given type and default time unit.
+     * Creates an unmodifiable {@link Counter}.
      *
-     * @param type the type to set; cannot be null
-     * @throws NullPointerException if the specified type is null
+     * @param counter the {@link Counter} to be wrapped; not null
+     * @throws NullPointerException if the specified counter is null
      */
     public UnmodifiableCounter(Counter counter)
     {

--- a/src/main/java/net/obvj/performetrics/UnmodifiableCounter.java
+++ b/src/main/java/net/obvj/performetrics/UnmodifiableCounter.java
@@ -22,7 +22,7 @@ import net.obvj.performetrics.util.Duration;
 
 /**
  * <p>
- * A "wrapper" class that allows retrieving values from a pre-built {@link Counter} but
+ * A "wrapper" class that allows retrieving values from a pre-existing {@link Counter} but
  * prevents users from modifying it.
  * </p>
  *
@@ -40,7 +40,7 @@ public final class UnmodifiableCounter extends Counter
      * @param counter the {@link Counter} to be wrapped; not null
      * @throws NullPointerException if the specified counter is null
      */
-    public UnmodifiableCounter(Counter counter)
+    public UnmodifiableCounter(final Counter counter)
     {
         super(counter.getType(), counter.getTimeUnit(), counter.getConversionMode());
         this.counter = counter;
@@ -49,126 +49,63 @@ public final class UnmodifiableCounter extends Counter
     private static UnsupportedOperationException unsupportedOperation(String methodName)
     {
         return new UnsupportedOperationException(
-                String.format("%s operation received on an unmodifiable Counter", methodName));
+                String.format("\"%s\" not allowed (unmodifiable Counter)", methodName));
     }
 
-    /**
-     * Returns the value of the {@code unitsBefore} field.
-     *
-     * @return the value of the {@code unitsBefore} field
-     */
     @Override
     public long getUnitsBefore()
     {
         return counter.getUnitsBefore();
     }
 
-    /**
-     * Populates the {@code unitsBefore} field with an arbitrary value.
-     *
-     * @param unitsBefore the units to be set
-     */
     @Override
     public void setUnitsBefore(long unitsBefore)
     {
         throw unsupportedOperation("setUnitsBefore");
     }
 
-    /**
-     * Returns the value of the {@code unitsAfter} field.
-     *
-     * @return the value of the {@code unitsAfter} field
-     */
     @Override
     public long getUnitsAfter()
     {
         return counter.getUnitsAfter();
     }
 
-    /**
-     * Populates the {@code unitsAfter} field with an arbitrary value.
-     *
-     * @param unitsAfter the units to be set
-     */
     @Override
     public void setUnitsAfter(long unitsAfter)
     {
         throw unsupportedOperation("setUnitsAfter");
     }
 
-    /**
-     * Populates the {@code unitsBefore} field with the value retrieved by the time source
-     * defined by this counter's type.
-     */
     @Override
     void setUnitsBefore()
     {
         throw unsupportedOperation("setUnitsBefore");
     }
 
-    /**
-     * Populates the {@code unitsAfter} field with the value retrieved by the time source
-     * defined by this counter's type.
-     */
     @Override
     void setUnitsAfter()
     {
         throw unsupportedOperation("setUnitsAfter");
     }
 
-    /**
-     * Returns the elapsed time.
-     *
-     * @return the difference between {@code unitsBefore} and {@code unitsAfter}, if both
-     *         units are set; or the difference between {@code unitsBefore} and the current
-     *         value retrieved by the counter's time source, if {@code unitsAfter} is not set.
-     */
     @Override
     public Duration elapsedTime()
     {
         return counter.elapsedTime();
     }
 
-    /**
-     * Returns the elapsed time in the specified {@link TimeUnit}.
-     *
-     * @param timeUnit the time unit to which the elapsed time will be converted
-     * @return the difference between {@code unitsBefore} and {@code unitsAfter}, if both
-     *         units are set; or the difference between {@code unitsBefore} and the current
-     *         value retrieved by the counter's time source, if {@code unitsAfter} is not set.
-     *         The value is converted into the specified time unit applying the default
-     *         conversion mode.
-     */
     @Override
     public double elapsedTime(TimeUnit timeUnit)
     {
         return counter.elapsedTime(timeUnit);
     }
 
-    /**
-     * Returns the elapsed time, in a given {@link TimeUnit}, with a custom
-     * {@link ConversionMode}.
-     *
-     * @param timeUnit       the time unit to which the elapsed time will be converted
-     * @param conversionMode the {@link ConversionMode} to be used
-     * @return the difference between {@code unitsBefore} and {@code unitsAfter}, if both
-     *         units are set; or the difference between {@code unitsBefore} and the current
-     *         value retrieved by the counter's time source, if {@code unitsAfter} is not set.
-     *         The value is converted into the specified time unit applying the given
-     *         conversion mode.
-     * @since 2.0.0
-     */
     @Override
     public double elapsedTime(TimeUnit timeUnit, ConversionMode conversionMode)
     {
         return counter.elapsedTime(timeUnit, conversionMode);
     }
 
-    /**
-     * Returns a string representation of this object.
-     *
-     * @see Object#toString()
-     */
     @Override
     public String toString()
     {

--- a/src/main/java/net/obvj/performetrics/UnmodifiableCounter.java
+++ b/src/main/java/net/obvj/performetrics/UnmodifiableCounter.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2024 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.performetrics;
+
+import java.util.concurrent.TimeUnit;
+
+import net.obvj.performetrics.util.Duration;
+
+/**
+ * <p>
+ * A "wrapper" class that allows retrieving values from a pre-built {@link Counter} but
+ * prevents users from modifying it.
+ * </p>
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 2.5.1
+ * @see Counter
+ */
+public final class UnmodifiableCounter extends Counter
+{
+    private final Counter counter;
+
+    /**
+     * Builds a Counter with a given type and default time unit.
+     *
+     * @param type the type to set; cannot be null
+     * @throws NullPointerException if the specified type is null
+     */
+    public UnmodifiableCounter(Counter counter)
+    {
+        super(counter.getType(), counter.getTimeUnit(), counter.getConversionMode());
+        this.counter = counter;
+    }
+
+    private static UnsupportedOperationException unsupportedOperation(String methodName)
+    {
+        return new UnsupportedOperationException(
+                String.format("%s operation received on an unmodifiable Counter", methodName));
+    }
+
+    /**
+     * Returns the value of the {@code unitsBefore} field.
+     *
+     * @return the value of the {@code unitsBefore} field
+     */
+    @Override
+    public long getUnitsBefore()
+    {
+        return counter.getUnitsBefore();
+    }
+
+    /**
+     * Populates the {@code unitsBefore} field with an arbitrary value.
+     *
+     * @param unitsBefore the units to be set
+     */
+    @Override
+    public void setUnitsBefore(long unitsBefore)
+    {
+        throw unsupportedOperation("setUnitsBefore");
+    }
+
+    /**
+     * Returns the value of the {@code unitsAfter} field.
+     *
+     * @return the value of the {@code unitsAfter} field
+     */
+    @Override
+    public long getUnitsAfter()
+    {
+        return counter.getUnitsAfter();
+    }
+
+    /**
+     * Populates the {@code unitsAfter} field with an arbitrary value.
+     *
+     * @param unitsAfter the units to be set
+     */
+    @Override
+    public void setUnitsAfter(long unitsAfter)
+    {
+        throw unsupportedOperation("setUnitsAfter");
+    }
+
+    /**
+     * Populates the {@code unitsBefore} field with the value retrieved by the time source
+     * defined by this counter's type.
+     */
+    @Override
+    void setUnitsBefore()
+    {
+        throw unsupportedOperation("setUnitsBefore");
+    }
+
+    /**
+     * Populates the {@code unitsAfter} field with the value retrieved by the time source
+     * defined by this counter's type.
+     */
+    @Override
+    void setUnitsAfter()
+    {
+        throw unsupportedOperation("setUnitsAfter");
+    }
+
+    /**
+     * Returns the elapsed time.
+     *
+     * @return the difference between {@code unitsBefore} and {@code unitsAfter}, if both
+     *         units are set; or the difference between {@code unitsBefore} and the current
+     *         value retrieved by the counter's time source, if {@code unitsAfter} is not set.
+     */
+    @Override
+    public Duration elapsedTime()
+    {
+        return counter.elapsedTime();
+    }
+
+    /**
+     * Returns the elapsed time in the specified {@link TimeUnit}.
+     *
+     * @param timeUnit the time unit to which the elapsed time will be converted
+     * @return the difference between {@code unitsBefore} and {@code unitsAfter}, if both
+     *         units are set; or the difference between {@code unitsBefore} and the current
+     *         value retrieved by the counter's time source, if {@code unitsAfter} is not set.
+     *         The value is converted into the specified time unit applying the default
+     *         conversion mode.
+     */
+    @Override
+    public double elapsedTime(TimeUnit timeUnit)
+    {
+        return counter.elapsedTime(timeUnit);
+    }
+
+    /**
+     * Returns the elapsed time, in a given {@link TimeUnit}, with a custom
+     * {@link ConversionMode}.
+     *
+     * @param timeUnit       the time unit to which the elapsed time will be converted
+     * @param conversionMode the {@link ConversionMode} to be used
+     * @return the difference between {@code unitsBefore} and {@code unitsAfter}, if both
+     *         units are set; or the difference between {@code unitsBefore} and the current
+     *         value retrieved by the counter's time source, if {@code unitsAfter} is not set.
+     *         The value is converted into the specified time unit applying the given
+     *         conversion mode.
+     * @since 2.0.0
+     */
+    @Override
+    public double elapsedTime(TimeUnit timeUnit, ConversionMode conversionMode)
+    {
+        return counter.elapsedTime(timeUnit, conversionMode);
+    }
+
+    /**
+     * Returns a string representation of this object.
+     *
+     * @see Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        return counter.toString();
+    }
+
+}

--- a/src/main/java/net/obvj/performetrics/UnmodifiableTimingSession.java
+++ b/src/main/java/net/obvj/performetrics/UnmodifiableTimingSession.java
@@ -40,12 +40,12 @@ public final class UnmodifiableTimingSession extends TimingSession
     private final TimingSession timingSession;
 
     /**
-     * Creates an unmodifiable object for a preset {@link TimingSession}.
+     * Creates an unmodifiable object for a pre-existing {@link TimingSession}.
      *
      * @param timingSession the {@link TimingSession} to be wrapped; not null
      * @throws NullPointerException if the {@link TimingSession} to be wrapped is null
      */
-    public UnmodifiableTimingSession(TimingSession timingSession)
+    public UnmodifiableTimingSession(final TimingSession timingSession)
     {
         super(requireNonNull(timingSession, "the TimingSession to be wrapped must not be null").getTypes());
         this.timingSession = timingSession;
@@ -54,7 +54,7 @@ public final class UnmodifiableTimingSession extends TimingSession
     private static UnsupportedOperationException unsupportedOperation(String methodName)
     {
         return new UnsupportedOperationException(String
-                .format("%s operation received on an unmodifiable TimingSession", methodName));
+                .format("\"%s\" not allowed (unmodifiable TimingSession)", methodName));
     }
 
     @Override

--- a/src/main/java/net/obvj/performetrics/UnmodifiableTimingSession.java
+++ b/src/main/java/net/obvj/performetrics/UnmodifiableTimingSession.java
@@ -17,6 +17,7 @@
 package net.obvj.performetrics;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -101,13 +102,15 @@ public final class UnmodifiableTimingSession extends TimingSession
     @Override
     Collection<Counter> getCounters()
     {
-        return timingSession.getCounters();
+        return timingSession.getCounters().stream()
+                .map(UnmodifiableCounter::new)
+                .collect(toList());
     }
 
     @Override
     Counter getCounter(Type type)
     {
-        return timingSession.getCounter(type);
+        return new UnmodifiableCounter(timingSession.getCounter(type));
     }
 
 }

--- a/src/test/java/net/obvj/performetrics/CounterTest.java
+++ b/src/test/java/net/obvj/performetrics/CounterTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mockStatic;
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.*;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -88,35 +89,35 @@ class CounterTest
         assertThat(counter.toString(), is(equalTo(expectedString)));
     }
 
-    @Test
-    void elapsedTimeInternal_withUnitsSet_returnsDifferenceInSeconds()
-    {
-        Counter counter = new Counter(SYSTEM_TIME, SECONDS);
-        assertThat(counter.getTimeUnit(), is(equalTo(SECONDS)));
-        counter.setUnitsBefore(2);
-        counter.setUnitsAfter(3); // 1 second after
-        assertThat(counter.elapsedTimeInternal(), is(equalTo(1L)));
-    }
-
-    @Test
-    void elapsedTimeInternal_withUnitsSet_returnsDifferenceInMilliseconds()
-    {
-        Counter counter = new Counter(SYSTEM_TIME, MILLISECONDS);
-        assertThat(counter.getTimeUnit(), is(equalTo(MILLISECONDS)));
-        counter.setUnitsBefore(1000);
-        counter.setUnitsAfter(1500); // 500 milliseconds after
-        assertThat(counter.elapsedTimeInternal(), is(500L));
-    }
-
-    @Test
-    void elapsedTimeInternal_withUnitsSet_returnsDifferenceInNanoseconds()
-    {
-        Counter counter = new Counter(SYSTEM_TIME, NANOSECONDS);
-        assertThat(counter.getTimeUnit(), is(NANOSECONDS));
-        counter.setUnitsBefore(1000000000L);
-        counter.setUnitsAfter(6000000000L); // 5 seconds after
-        assertThat(counter.elapsedTimeInternal(), is(equalTo(5000000000L)));
-    }
+    // @Test
+    // void elapsedTimeInternal_withUnitsSet_returnsDifferenceInSeconds()
+    // {
+    // Counter counter = new Counter(SYSTEM_TIME, SECONDS);
+    // assertThat(counter.getTimeUnit(), is(equalTo(SECONDS)));
+    // counter.setUnitsBefore(2);
+    // counter.setUnitsAfter(3); // 1 second after
+    // assertThat(counter.elapsedTimeInternal(), is(equalTo(1L)));
+    // }
+    //
+    // @Test
+    // void elapsedTimeInternal_withUnitsSet_returnsDifferenceInMilliseconds()
+    // {
+    // Counter counter = new Counter(SYSTEM_TIME, MILLISECONDS);
+    // assertThat(counter.getTimeUnit(), is(equalTo(MILLISECONDS)));
+    // counter.setUnitsBefore(1000);
+    // counter.setUnitsAfter(1500); // 500 milliseconds after
+    // assertThat(counter.elapsedTimeInternal(), is(500L));
+    // }
+    //
+    // @Test
+    // void elapsedTimeInternal_withUnitsSet_returnsDifferenceInNanoseconds()
+    // {
+    // Counter counter = new Counter(SYSTEM_TIME, NANOSECONDS);
+    // assertThat(counter.getTimeUnit(), is(NANOSECONDS));
+    // counter.setUnitsBefore(1000000000L);
+    // counter.setUnitsAfter(6000000000L); // 5 seconds after
+    // assertThat(counter.elapsedTimeInternal(), is(equalTo(5000000000L)));
+    // }
 
     @Test
     void elapsedTime_withTimeUnitEqualToTheOriginal_returnsDifferenceInOriginalTimeUnit()
@@ -149,24 +150,25 @@ class CounterTest
     }
 
     @Test
-    void elapsedTimeInternal_withUnitsBeforeSetOnly_returnsDifferenceBetweenUnitsBeforeAndCurrentTime()
+    void elapsedTime_withUnitsBeforeSetOnly_returnsDifferenceBetweenUnitsBeforeAndCurrentTime()
     {
         Counter counter = new Counter(WALL_CLOCK_TIME, NANOSECONDS);
         counter.setUnitsBefore(2000);
         try (MockedStatic<SystemUtils> systemUtils = mockStatic(SystemUtils.class))
         {
             systemUtils.when(SystemUtils::getWallClockTimeNanos).thenReturn(9000L);
-            assertThat(counter.elapsedTimeInternal(), is(equalTo(7000L)));
+            assertThat(counter.elapsedTime(), is(equalTo(Duration.of(7000L, NANOSECONDS))));
         }
     }
 
     @Test
-    void elapsedTimeInternal_unitsAfterLowerThanUnitsBefore_negative1()
+    void elapsedTime_unitsAfterLowerThanUnitsBefore_negative1()
     {
         Counter counter = new Counter(WALL_CLOCK_TIME);
         counter.setUnitsBefore(5000);
         counter.setUnitsAfter(500);
-        assertThat(counter.elapsedTimeInternal(), is(equalTo(-1L)));
+        assertThat(() -> counter.elapsedTime(), throwsException(IllegalArgumentException.class)
+                .withMessage("The duration amount must be a positive value"));
     }
 
     @Test

--- a/src/test/java/net/obvj/performetrics/CounterTest.java
+++ b/src/test/java/net/obvj/performetrics/CounterTest.java
@@ -89,36 +89,6 @@ class CounterTest
         assertThat(counter.toString(), is(equalTo(expectedString)));
     }
 
-    // @Test
-    // void elapsedTimeInternal_withUnitsSet_returnsDifferenceInSeconds()
-    // {
-    // Counter counter = new Counter(SYSTEM_TIME, SECONDS);
-    // assertThat(counter.getTimeUnit(), is(equalTo(SECONDS)));
-    // counter.setUnitsBefore(2);
-    // counter.setUnitsAfter(3); // 1 second after
-    // assertThat(counter.elapsedTimeInternal(), is(equalTo(1L)));
-    // }
-    //
-    // @Test
-    // void elapsedTimeInternal_withUnitsSet_returnsDifferenceInMilliseconds()
-    // {
-    // Counter counter = new Counter(SYSTEM_TIME, MILLISECONDS);
-    // assertThat(counter.getTimeUnit(), is(equalTo(MILLISECONDS)));
-    // counter.setUnitsBefore(1000);
-    // counter.setUnitsAfter(1500); // 500 milliseconds after
-    // assertThat(counter.elapsedTimeInternal(), is(500L));
-    // }
-    //
-    // @Test
-    // void elapsedTimeInternal_withUnitsSet_returnsDifferenceInNanoseconds()
-    // {
-    // Counter counter = new Counter(SYSTEM_TIME, NANOSECONDS);
-    // assertThat(counter.getTimeUnit(), is(NANOSECONDS));
-    // counter.setUnitsBefore(1000000000L);
-    // counter.setUnitsAfter(6000000000L); // 5 seconds after
-    // assertThat(counter.elapsedTimeInternal(), is(equalTo(5000000000L)));
-    // }
-
     @Test
     void elapsedTime_withTimeUnitEqualToTheOriginal_returnsDifferenceInOriginalTimeUnit()
     {

--- a/src/test/java/net/obvj/performetrics/UnmodifiableCounterTest.java
+++ b/src/test/java/net/obvj/performetrics/UnmodifiableCounterTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2024 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.performetrics;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.throwsException;
+import static net.obvj.performetrics.ConversionMode.DOUBLE_PRECISION;
+import static net.obvj.performetrics.ConversionMode.FAST;
+import static net.obvj.performetrics.Counter.Type.CPU_TIME;
+import static net.obvj.performetrics.Counter.Type.SYSTEM_TIME;
+import static net.obvj.performetrics.Counter.Type.WALL_CLOCK_TIME;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import net.obvj.performetrics.util.Duration;
+import net.obvj.performetrics.util.SystemUtils;
+
+/**
+ * Unit tests for the {@link UnmodifiableCounter} class.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 2.5.1
+ */
+class UnmodifiableCounterTest
+{
+
+    @Test
+    void getters_succeed()
+    {
+        Counter counter = new Counter(CPU_TIME, MILLISECONDS);
+        counter.setUnitsBefore(5);
+        counter.setUnitsAfter(10);
+
+        Counter unmodifiable = new UnmodifiableCounter(counter);
+        assertThat(unmodifiable.getType(), is(equalTo(CPU_TIME)));
+        assertThat(unmodifiable.getTimeUnit(), is(equalTo(MILLISECONDS)));
+        assertThat(unmodifiable.getUnitsBefore(), is(equalTo(5L)));
+        assertThat(unmodifiable.getUnitsAfter(), is(equalTo(10L)));
+    }
+
+    @Test
+    void toString_withAllFieldsSet_suceeds()
+    {
+        Counter counter = new Counter(WALL_CLOCK_TIME, MILLISECONDS);
+        counter.setUnitsBefore(500);
+        counter.setUnitsAfter(1000);
+
+        Counter unmodifiable = new UnmodifiableCounter(counter);
+        assertThat(unmodifiable.toString(), is(equalTo(counter.toString())));
+    }
+
+    @Test
+    void elapsedTime_withTimeUnitEqualToTheOriginal_returnsDifferenceInOriginalTimeUnit()
+    {
+        Counter counter = new Counter(SYSTEM_TIME, SECONDS);
+        assertThat(counter.getTimeUnit(), is(SECONDS));
+        counter.setUnitsBefore(2);
+        counter.setUnitsAfter(3);
+
+        Counter unmodifiable = new UnmodifiableCounter(counter);
+        assertThat(unmodifiable.elapsedTime(SECONDS), is(equalTo(1.0)));
+    }
+
+    @Test
+    void elapsedTime_withTimeUnitLowerThanOriginal_returnsDifferenceConverted()
+    {
+        Counter counter = new Counter(SYSTEM_TIME, SECONDS);
+        assertThat(counter.getTimeUnit(), is(SECONDS));
+        counter.setUnitsBefore(2);
+        counter.setUnitsAfter(3);
+
+        Counter unmodifiable = new UnmodifiableCounter(counter);
+        assertThat(unmodifiable.elapsedTime(MILLISECONDS), is(equalTo(1000.0)));
+    }
+
+    @Test
+    void elapsedTime_withTimeUnitHigherThanOriginal_returnsDifferenceConverted()
+    {
+        Counter counter = new Counter(SYSTEM_TIME, MILLISECONDS);
+        assertThat(counter.getTimeUnit(), is(MILLISECONDS));
+        counter.setUnitsBefore(2000);
+        counter.setUnitsAfter(3500); // 1.5 second after
+
+        Counter unmodifiable = new UnmodifiableCounter(counter);
+        assertThat(unmodifiable.elapsedTime(SECONDS), is(equalTo(1.5)));
+    }
+
+    @Test
+    void elapsedTime_withoutParams_returnsDifferenceBetweenUnitsBeforeAndCurrentTime()
+    {
+        Counter counter = new Counter(WALL_CLOCK_TIME, NANOSECONDS);
+        counter.setUnitsBefore(2000);
+        try (MockedStatic<SystemUtils> systemUtils = mockStatic(SystemUtils.class))
+        {
+            systemUtils.when(SystemUtils::getWallClockTimeNanos).thenReturn(9000L);
+            Counter unmodifiable = new UnmodifiableCounter(counter);
+            assertThat(unmodifiable.elapsedTime(), is(equalTo(Duration.of(7000L, NANOSECONDS))));
+        }
+    }
+
+    @Test
+    void elapsedTime_withFinerTimeUnitAndDoublePrecisionConversion_conversionSuceeds()
+    {
+        Counter counter = new Counter(SYSTEM_TIME, SECONDS, DOUBLE_PRECISION);
+        assertThat(counter.getTimeUnit(), is(SECONDS));
+        counter.setUnitsAfter(2); // 2 seconds
+        Counter unmodifiable = new UnmodifiableCounter(counter);
+        assertThat(unmodifiable.elapsedTime(MILLISECONDS), is(equalTo(2000.0)));
+    }
+
+    @Test
+    void elapsedTime_withTimeUnitAndCustomConversionMode_appliesCustomConversion()
+    {
+        Counter counter = new Counter(SYSTEM_TIME, MILLISECONDS);
+        assertThat(counter.getTimeUnit(), is(MILLISECONDS));
+        counter.setUnitsBefore(2000);
+        counter.setUnitsAfter(3500); // 1.5 second after
+        Counter unmodifiable = new UnmodifiableCounter(counter);
+        assertThat(unmodifiable.elapsedTime(SECONDS, FAST), is(equalTo(1.0)));
+    }
+
+    @Test
+    void setUnitsBefore_withParameter_unsupportedOperation()
+    {
+        Counter unmodifiable = new UnmodifiableCounter(new Counter(SYSTEM_TIME));
+        assertThat(() -> unmodifiable.setUnitsBefore(99L),
+                throwsException(UnsupportedOperationException.class)
+                        .withMessage("\"setUnitsBefore\" not allowed (unmodifiable Counter)"));
+    }
+
+    @Test
+    void setUnitsBefore_noParameter_unsupportedOperation()
+    {
+        Counter unmodifiable = new UnmodifiableCounter(new Counter(SYSTEM_TIME));
+        assertThat(() -> unmodifiable.setUnitsBefore(),
+                throwsException(UnsupportedOperationException.class)
+                        .withMessage("\"setUnitsBefore\" not allowed (unmodifiable Counter)"));
+    }
+
+    @Test
+    void setUnitsAfter_withParameter_unsupportedOperation()
+    {
+        Counter unmodifiable = new UnmodifiableCounter(new Counter(SYSTEM_TIME));
+        assertThat(() -> unmodifiable.setUnitsAfter(99L),
+                throwsException(UnsupportedOperationException.class)
+                        .withMessage("\"setUnitsAfter\" not allowed (unmodifiable Counter)"));
+    }
+
+    @Test
+    void setUnitsAfter_noParameter_unsupportedOperation()
+    {
+        Counter unmodifiable = new UnmodifiableCounter(new Counter(SYSTEM_TIME));
+        assertThat(() -> unmodifiable.setUnitsAfter(),
+                throwsException(UnsupportedOperationException.class)
+                        .withMessage("\"setUnitsAfter\" not allowed (unmodifiable Counter)"));
+    }
+
+}


### PR DESCRIPTION
## Issue
When somebody calls `Stopwatch.lastSession()`, the system returns an `UnmodifiableTimingSession` for safety. But when one calls `UnmodifiableTimingSession.getCounter(...)`, the system returns the actual `Counter`.

### Expected result
It should return an `UnmodifiableCounter` to avoid unexpected behaviors in the `Stopwatch`.