### PR TITLE
Optimization pack 2

### DIFF
--- a/src/main/java/net/obvj/performetrics/Counter.java
+++ b/src/main/java/net/obvj/performetrics/Counter.java
@@ -27,7 +27,8 @@ import net.obvj.performetrics.util.SystemUtils;
 
 /**
  * <p>
- * An object that stores time units (in nanoseconds) for elapsed time evaluation.
+ * An object that stores time units for a particular counter type (in nanoseconds) for
+ * elapsed time evaluation.
  * </p>
  * <p>
  * The associated counter type defines the time fetch strategy applied by the methods

--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -17,7 +17,6 @@
 package net.obvj.performetrics;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import net.obvj.performetrics.Counter.Type;
 import net.obvj.performetrics.config.ConfigurationHolder;
@@ -47,16 +46,6 @@ public class Performetrics
     private Performetrics()
     {
         throw new IllegalStateException("Instantiation not allowed");
-    }
-
-    /**
-     * Sets a time unit to be maintained by default if no specific time unit is specified.
-     *
-     * @param timeUnit the {@link TimeUnit} to set
-     */
-    public static void setDefaultTimeUnit(TimeUnit timeUnit)
-    {
-        ConfigurationHolder.getConfiguration().setTimeUnit(timeUnit);
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/TimingSession.java
+++ b/src/main/java/net/obvj/performetrics/TimingSession.java
@@ -300,11 +300,13 @@ public class TimingSession
      */
     Counter getCounter(Type type)
     {
-        if (!counters.containsKey(type))
+        Counter counter = counters.get(type);
+        if (counter == null)
         {
-            throw new IllegalArgumentException(MessageFormat.format(MSG_TYPE_NOT_SPECIFIED, type, counters.keySet()));
+            throw new IllegalArgumentException(
+                    MessageFormat.format(MSG_TYPE_NOT_SPECIFIED, type, counters.keySet()));
         }
-        return counters.get(type);
+        return counter;
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/UnmodifiableCounter.java
+++ b/src/main/java/net/obvj/performetrics/UnmodifiableCounter.java
@@ -42,7 +42,7 @@ public final class UnmodifiableCounter extends Counter
      */
     public UnmodifiableCounter(final Counter counter)
     {
-        super(counter.getType(), counter.getTimeUnit(), counter.getConversionMode());
+        super(counter.getType(), counter.getConversionMode());
         this.counter = counter;
     }
 

--- a/src/main/java/net/obvj/performetrics/config/Configuration.java
+++ b/src/main/java/net/obvj/performetrics/config/Configuration.java
@@ -17,7 +17,6 @@
 package net.obvj.performetrics.config;
 
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 import net.obvj.performetrics.ConversionMode;
 import net.obvj.performetrics.Stopwatch;
@@ -32,10 +31,6 @@ import net.obvj.performetrics.util.print.PrintStyle;
  */
 public class Configuration
 {
-    /**
-     * The initial time unit to be maintained if no specific time unit informed.
-     */
-    static final TimeUnit INITIAL_TIME_UNIT = TimeUnit.NANOSECONDS;
 
     /**
      * The initial conversion mode to be applied if no specific mode is set.
@@ -73,7 +68,6 @@ public class Configuration
 
     private static final String MSG_PRINT_STYLE_MUST_NOT_BE_NULL = "The default PrintStyle must not be null";
 
-    private TimeUnit timeUnit;
     private ConversionMode conversionMode;
     private int scale;
     private PrintStyle printStyle;
@@ -85,34 +79,11 @@ public class Configuration
      */
     public Configuration()
     {
-        timeUnit = INITIAL_TIME_UNIT;
         conversionMode = INITIAL_CONVERSION_MODE;
         scale = INITIAL_SCALE;
         printStyle = INITIAL_PRINT_STYLE;
         printStyleForSummary = INITIAL_PRINT_STYLE_FOR_SUMMARY;
         printStyleForDetails = INITIAL_PRINT_STYLE_FOR_DETAILS;
-    }
-
-    /**
-     * Returns the time unit maintained by default if no specific time unit is specified.
-     *
-     * @return the time unit maintained by default
-     */
-    public TimeUnit getTimeUnit()
-    {
-        return timeUnit;
-    }
-
-    /**
-     * Defines the time unit to be maintained by default if no specific time unit is
-     * specified.
-     *
-     * @param timeUnit the {@link TimeUnit} to set
-     * @throws NullPointerException if the specified time unit is null
-     */
-    public void setTimeUnit(TimeUnit timeUnit)
-    {
-        this.timeUnit = Objects.requireNonNull(timeUnit, "the default time unit must not be null");
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/util/DurationUtils.java
+++ b/src/main/java/net/obvj/performetrics/util/DurationUtils.java
@@ -40,7 +40,7 @@ public class DurationUtils
      */
     public static Duration average(Collection<Duration> durations)
     {
-        if (durations == null || durations.isEmpty())
+        if (isEmpty(durations))
         {
             return Duration.ZERO;
         }
@@ -67,7 +67,7 @@ public class DurationUtils
      */
     public static Duration min(Collection<Duration> durations)
     {
-        if (durations == null || durations.isEmpty())
+        if (isEmpty(durations))
         {
             return Duration.ZERO;
         }
@@ -84,12 +84,17 @@ public class DurationUtils
      */
     public static Duration max(Collection<Duration> durations)
     {
-        if (durations == null || durations.isEmpty())
+        if (isEmpty(durations))
         {
             return Duration.ZERO;
         }
         // We compare the seconds with the fractional nanoseconds after the decimal point
         return durations.stream().max(Comparable::compareTo).orElse(Duration.ZERO);
+    }
+
+    private static boolean isEmpty(Collection<?> collection)
+    {
+        return collection == null || collection.isEmpty();
     }
 
 }

--- a/src/main/java/net/obvj/performetrics/util/SystemUtils.java
+++ b/src/main/java/net/obvj/performetrics/util/SystemUtils.java
@@ -76,8 +76,13 @@ public class SystemUtils
      **/
     public static long getCpuTimeNanos()
     {
-        return THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported()
-                ? THREAD_MX_BEAN.getCurrentThreadCpuTime()
+        return getCpuTimeNanos(THREAD_MX_BEAN);
+    }
+
+    static long getCpuTimeNanos(ThreadMXBean threadMXBean)
+    {
+        return threadMXBean.isCurrentThreadCpuTimeSupported()
+                ? threadMXBean.getCurrentThreadCpuTime()
                 : -1L;
     }
 
@@ -90,8 +95,13 @@ public class SystemUtils
      **/
     public static long getUserTimeNanos()
     {
-        return THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported()
-                ? THREAD_MX_BEAN.getCurrentThreadUserTime()
+        return getUserTimeNanos(THREAD_MX_BEAN);
+    }
+
+    public static long getUserTimeNanos(ThreadMXBean threadMXBean)
+    {
+        return threadMXBean.isCurrentThreadCpuTimeSupported()
+                ? threadMXBean.getCurrentThreadUserTime()
                 : -1L;
     }
 
@@ -105,9 +115,13 @@ public class SystemUtils
      */
     public static long getSystemTimeNanos()
     {
-        return THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported()
-                ? (THREAD_MX_BEAN.getCurrentThreadCpuTime()
-                        - THREAD_MX_BEAN.getCurrentThreadUserTime())
+        return getSystemTimeNanos(THREAD_MX_BEAN);
+    }
+
+    public static long getSystemTimeNanos(ThreadMXBean threadMXBean)
+    {
+        return threadMXBean.isCurrentThreadCpuTimeSupported()
+                ? (threadMXBean.getCurrentThreadCpuTime() - threadMXBean.getCurrentThreadUserTime())
                 : -1L;
     }
 }

--- a/src/main/java/net/obvj/performetrics/util/SystemUtils.java
+++ b/src/main/java/net/obvj/performetrics/util/SystemUtils.java
@@ -27,6 +27,8 @@ import java.lang.management.ThreadMXBean;
 public class SystemUtils
 {
 
+    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+
     /**
      * This is a utility class, not meant to be instantiated.
      */
@@ -49,6 +51,14 @@ public class SystemUtils
     /**
      * Returns the current value of the current Java Virtual Machine's high-resolution time
      * source in nanoseconds.
+     * <p>
+     * This is a convenience method and is equivalent to calling:
+     * <blockquote>
+     * {@code System.nanoTime();}
+     * </blockquote>
+     * <p>
+     * <b>Note:</b> This method provides nanosecond precision, but not necessarily nanosecond
+     * resolution.
      *
      * @return the difference, measured in nanoseconds between current time and some arbitrary
      *         origin time for the current JVM, that can be used for measuring elapsed times.
@@ -66,8 +76,9 @@ public class SystemUtils
      **/
     public static long getCpuTimeNanos()
     {
-        ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-        return bean.isCurrentThreadCpuTimeSupported() ? bean.getCurrentThreadCpuTime() : -1L;
+        return THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported()
+                ? THREAD_MX_BEAN.getCurrentThreadCpuTime()
+                : -1L;
     }
 
     /**
@@ -79,8 +90,9 @@ public class SystemUtils
      **/
     public static long getUserTimeNanos()
     {
-        ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-        return bean.isCurrentThreadCpuTimeSupported() ? bean.getCurrentThreadUserTime() : -1L;
+        return THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported()
+                ? THREAD_MX_BEAN.getCurrentThreadUserTime()
+                : -1L;
     }
 
     /**
@@ -93,9 +105,9 @@ public class SystemUtils
      */
     public static long getSystemTimeNanos()
     {
-        ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-        return bean.isCurrentThreadCpuTimeSupported()
-                ? (bean.getCurrentThreadCpuTime() - bean.getCurrentThreadUserTime())
+        return THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported()
+                ? (THREAD_MX_BEAN.getCurrentThreadCpuTime()
+                        - THREAD_MX_BEAN.getCurrentThreadUserTime())
                 : -1L;
     }
 }

--- a/src/test/java/net/obvj/performetrics/PerformetricsTest.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTest.java
@@ -16,7 +16,6 @@
 
 package net.obvj.performetrics;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static net.obvj.junit.utils.matchers.AdvancedMatchers.instantiationNotAllowed;
 import static net.obvj.performetrics.ConversionMode.DOUBLE_PRECISION;
 import static net.obvj.performetrics.ConversionMode.FAST;
@@ -29,8 +28,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +48,6 @@ import net.obvj.performetrics.util.print.PrintStyle;
 class PerformetricsTest
 {
     // Default values
-    private static final TimeUnit INITIAL_TIME_UNIT = ConfigurationHolder.getConfiguration().getTimeUnit();
     private static final ConversionMode INITIAL_CONVERSION_MODE = ConfigurationHolder.getConfiguration().getConversionMode();
     private static final int INITIAL_SCALE = ConfigurationHolder.getConfiguration().getScale();
     private static final PrintStyle INITIAL_PRINT_STYLE = ConfigurationHolder.getConfiguration().getPrintStyle();
@@ -75,17 +71,11 @@ class PerformetricsTest
 
     private void checkAllDefaultValues()
     {
-        checkDefaultTimeUnit();
         checkDefaultConversionMode();
         checkDefaulScale();
         checkDefaulPrintStyle();
         checkDefaulPrintStyleForSummary();
         checkDefaulPrintStyleForDetails();
-    }
-
-    private void checkDefaultTimeUnit()
-    {
-        assertThat(ConfigurationHolder.getConfiguration().getTimeUnit(), is(equalTo(INITIAL_TIME_UNIT)));
     }
 
     private void checkDefaultConversionMode()
@@ -127,22 +117,9 @@ class PerformetricsTest
     {
         Performetrics.setDefaultConversionMode(FAST);
         assertThat(ConfigurationHolder.getConfiguration().getConversionMode(), is(equalTo(FAST)));
-        checkDefaultTimeUnit();
         checkDefaulScale();
         checkDefaulPrintStyleForSummary();
         checkDefaulPrintStyleForDetails();
-    }
-
-    @Test
-    void setDefaultTimeUnit_seconds_updatesConfiguration()
-    {
-        Performetrics.setDefaultTimeUnit(MILLISECONDS);
-        assertThat(ConfigurationHolder.getConfiguration().getTimeUnit(), is(equalTo(MILLISECONDS)));
-        checkDefaultConversionMode();
-        checkDefaulScale();
-        checkDefaulPrintStyleForSummary();
-        checkDefaulPrintStyleForDetails();
-
     }
 
     @Test
@@ -150,11 +127,9 @@ class PerformetricsTest
     {
         Performetrics.setDefaultConversionMode(DOUBLE_PRECISION);
         assertThat(ConfigurationHolder.getConfiguration().getConversionMode(), is(equalTo(DOUBLE_PRECISION)));
-        checkDefaultTimeUnit();
         checkDefaulScale();
         checkDefaulPrintStyleForSummary();
         checkDefaulPrintStyleForDetails();
-
     }
 
     @Test
@@ -162,7 +137,6 @@ class PerformetricsTest
     {
         Performetrics.setScale(16);
         assertThat(ConfigurationHolder.getConfiguration().getScale(), is(equalTo(16)));
-        checkDefaultTimeUnit();
         checkDefaultConversionMode();
         checkDefaulPrintStyleForSummary();
         checkDefaulPrintStyleForDetails();
@@ -222,7 +196,6 @@ class PerformetricsTest
         Performetrics.setDefaultPrintStyle(ps);
         assertThat(ConfigurationHolder.getConfiguration().getPrintStyle(), is(equalTo(ps)));
         checkDefaultConversionMode();
-        checkDefaultTimeUnit();
         checkDefaulScale();
         checkDefaulPrintStyleForSummary();
         checkDefaulPrintStyleForDetails();
@@ -248,7 +221,6 @@ class PerformetricsTest
         Performetrics.setDefaultPrintStyleForSummary(ps);
         assertThat(ConfigurationHolder.getConfiguration().getPrintStyleForSummary(), is(equalTo(ps)));
         checkDefaultConversionMode();
-        checkDefaultTimeUnit();
         checkDefaulScale();
         checkDefaulPrintStyle();
         checkDefaulPrintStyleForDetails();
@@ -274,7 +246,6 @@ class PerformetricsTest
         Performetrics.setDefaultPrintStyleForDetails(ps);
         assertThat(ConfigurationHolder.getConfiguration().getPrintStyleForDetails(), is(equalTo(ps)));
         checkDefaultConversionMode();
-        checkDefaultTimeUnit();
         checkDefaulScale();
         checkDefaulPrintStyle();
         checkDefaulPrintStyleForSummary();

--- a/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
@@ -25,11 +25,9 @@ import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
-import java.util.Locale;
-import java.util.Random;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import net.obvj.performetrics.monitors.MonitoredCallable;
 import net.obvj.performetrics.util.DurationFormat;
@@ -52,7 +50,11 @@ public class PerformetricsTestDrive
         Performetrics.setDefaultConversionMode(ConversionMode.DOUBLE_PRECISION);
         Performetrics.setScale(2);
 
+        System.out.println("\n\n****************************************************\n");
         testCallableWithLambda();
+
+        System.out.println("\n\n****************************************************\n");
+        testOnADifferentThread();
     }
 
     private static void testStopwatch1() throws InterruptedException, IOException
@@ -148,6 +150,30 @@ public class PerformetricsTestDrive
         }
 
         return BigInteger.valueOf(x).multiply(factorial(x - 1));
+    }
+
+    private static void testOnADifferentThread()
+    {
+        System.out.println("[main] Starting test on a different thread");
+        new Thread(() -> {
+            Performetrics.monitorOperation(() ->
+            {
+                String logFormat = "[%s] %s";
+                String threadName = Thread.currentThread().getName();
+                System.out.println(String.format(logFormat, threadName, "Running..."));
+
+                int size = 5_000_000;
+                IntStream.range(0, size)
+                        .mapToObj(i -> UUID.randomUUID())
+                        .map(UUID::toString)
+                        .sorted()
+                        .collect(Collectors.toSet());
+
+                System.out.println(String.format(logFormat, threadName, size + " UUIDs generated and sorted"));
+                System.out.println();
+            }).printSummary(System.out, PrintStyle.SUMMARIZED_YAML);
+        }).start();;
+        System.out.println("[main] New thread started");
     }
 
 }

--- a/src/test/java/net/obvj/performetrics/config/ConfigurationTest.java
+++ b/src/test/java/net/obvj/performetrics/config/ConfigurationTest.java
@@ -21,8 +21,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.Test;
 
 import net.obvj.performetrics.ConversionMode;
@@ -42,18 +40,10 @@ class ConfigurationTest
     @Test
     void constructor_default_defaultValues()
     {
-        assertThat(configuration.getTimeUnit(), is(equalTo(Configuration.INITIAL_TIME_UNIT)));
         assertThat(configuration.getConversionMode(), is(equalTo(Configuration.INITIAL_CONVERSION_MODE)));
         assertThat(configuration.getScale(), is(equalTo(Configuration.INITIAL_SCALE)));
         assertThat(configuration.getPrintStyleForSummary(), is(equalTo(Configuration.INITIAL_PRINT_STYLE_FOR_SUMMARY)));
         assertThat(configuration.getPrintStyleForDetails(), is(equalTo(Configuration.INITIAL_PRINT_STYLE_FOR_DETAILS)));
-    }
-
-    @Test
-    void setTimeUnit_validTimeUnit_suceeds()
-    {
-        configuration.setTimeUnit(TimeUnit.SECONDS);
-        assertThat(configuration.getTimeUnit(), is(equalTo(TimeUnit.SECONDS)));
     }
 
     @Test

--- a/src/test/java/net/obvj/performetrics/util/SystemUtilsTest.java
+++ b/src/test/java/net/obvj/performetrics/util/SystemUtilsTest.java
@@ -17,10 +17,15 @@
 package net.obvj.performetrics.util;
 
 import static net.obvj.junit.utils.matchers.AdvancedMatchers.instantiationNotAllowed;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.lang.management.ThreadMXBean;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 /**
  * Test methods for the {@link SystemUtils} class.
@@ -29,6 +34,9 @@ import org.junit.jupiter.api.Test;
  */
 class SystemUtilsTest
 {
+
+    ThreadMXBean mXBean = Mockito.mock(ThreadMXBean.class);
+
     @Test
     void constructor_instantiationNotAllowed()
     {
@@ -46,4 +54,51 @@ class SystemUtilsTest
     {
         assertThat(SystemUtils.getWallClockTimeNanos() > 0, is(true));
     }
+
+    @Test
+    void getCpuTimeNanos_supported_longValue()
+    {
+        when(mXBean.isCurrentThreadCpuTimeSupported()).thenReturn(true);
+        when(mXBean.getCurrentThreadCpuTime()).thenReturn(5_000_000L);
+        assertThat(SystemUtils.getCpuTimeNanos(mXBean), equalTo(5_000_000L));
+    }
+
+    @Test
+    void getCpuTimeNanos_notSupported_negative()
+    {
+        when(mXBean.isCurrentThreadCpuTimeSupported()).thenReturn(false);
+        assertThat(SystemUtils.getCpuTimeNanos(mXBean), equalTo(-1L));
+    }
+
+    @Test
+    void getUserTimeNanos_supported_longValue()
+    {
+        when(mXBean.isCurrentThreadCpuTimeSupported()).thenReturn(true);
+        when(mXBean.getCurrentThreadUserTime()).thenReturn(5_000_000L);
+        assertThat(SystemUtils.getUserTimeNanos(mXBean), equalTo(5_000_000L));
+    }
+
+    @Test
+    void getUserTimeNanos_notSupported_negative()
+    {
+        when(mXBean.isCurrentThreadCpuTimeSupported()).thenReturn(false);
+        assertThat(SystemUtils.getUserTimeNanos(mXBean), equalTo(-1L));
+    }
+
+    @Test
+    void getSystemTimeNanos_supported_longValue()
+    {
+        when(mXBean.isCurrentThreadCpuTimeSupported()).thenReturn(true);
+        when(mXBean.getCurrentThreadCpuTime()).thenReturn(5_000_000L);
+        when(mXBean.getCurrentThreadUserTime()).thenReturn(4_000_000L);
+        assertThat(SystemUtils.getSystemTimeNanos(mXBean), equalTo(1_000_000L));
+    }
+
+    @Test
+    void getSystemTimeNanos_notSupported_negative()
+    {
+        when(mXBean.isCurrentThreadCpuTimeSupported()).thenReturn(false);
+        assertThat(SystemUtils.getSystemTimeNanos(mXBean), equalTo(-1L));
+    }
+
 }

--- a/src/test/java/net/obvj/performetrics/util/TimeUnitConverterTest.java
+++ b/src/test/java/net/obvj/performetrics/util/TimeUnitConverterTest.java
@@ -93,4 +93,10 @@ class TimeUnitConverterTest
         assertThat(TimeUnitConverter.convert(999, TimeUnit.MILLISECONDS, TimeUnit.SECONDS), is(equalTo(0.999)));
     }
 
+    @Test
+    void convert_sameTimeUnit_success()
+    {
+        assertThat(TimeUnitConverter.convert(999, TimeUnit.NANOSECONDS, TimeUnit.NANOSECONDS), equalTo(999.0));
+    }
+
 }

--- a/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
@@ -17,8 +17,6 @@
 package net.obvj.performetrics.util.print;
 
 import static java.util.Collections.singletonList;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static net.obvj.junit.utils.matchers.AdvancedMatchers.instantiationNotAllowed;
 import static net.obvj.performetrics.Counter.Type.CPU_TIME;
 import static net.obvj.performetrics.Counter.Type.WALL_CLOCK_TIME;
@@ -36,7 +34,6 @@ import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,8 +52,8 @@ import net.obvj.performetrics.util.DurationFormat;
  */
 class PrintUtilsTest
 {
-    private static final Counter C1 = newCounter(WALL_CLOCK_TIME, MILLISECONDS, 5000, 6000);
-    private static final Counter C2 = newCounter(CPU_TIME, NANOSECONDS, 700000000000l, 900000000000l);
+    private static final Counter C1 = newCounter(WALL_CLOCK_TIME, 5_000, 6_000);
+    private static final Counter C2 = newCounter(CPU_TIME, 700_000_000_000L, 900_000_000_000L);
     private static final Map<Type, List<Counter>> ALL_COUNTERS = new EnumMap<>(Type.class);
     private static final List<Type> ALL_TYPES = Arrays.asList(WALL_CLOCK_TIME, CPU_TIME);
 
@@ -81,9 +78,9 @@ class PrintUtilsTest
         when(stopwatch.elapsedTime(CPU_TIME)).thenReturn(C2.elapsedTime());
     }
 
-    private static Counter newCounter(Type type, TimeUnit timeUnit, long unitsBefore, long unitsAfter)
+    private static Counter newCounter(Type type, long unitsBefore, long unitsAfter)
     {
-        Counter counter = new Counter(type, timeUnit);
+        Counter counter = new Counter(type);
         counter.setUnitsBefore(unitsBefore);
         counter.setUnitsAfter(unitsAfter);
         return counter;


### PR DESCRIPTION
# Enhancement

This Pull Request introduces the following optimization:

## Reduce time unit conversion overhead

The `Counter` class was originally designed so that the times collected by the `Counter` instances could be maintained in different `TimeUnit`s as specified by the constructor `Counter(Type, TimeUnit)`.

This flexibility comes with a cost: all units are converted during time-source fetching. However, in practice, only "nanoseconds" were used. Removing this feature means we no longer need intermediary time unit conversions. Now, the `Counter` class, by definition, will store amounts in nanoseconds, making the class cleaner and faster.

With this simplification, we also removed the "default time unit" setting that used to be applied when no other was specified.

**NOTE:** Elapsed times can still be converted normally using a `TimingSession` or a `TimingSessionContainer` (such as `Stopwatch`) but the units are stored only as nanoseconds at the `Counter` level.

## Other minor improvements

- **`SystemUtils` class optimization:**
  - Store a local reference for the `ThreadMXBean` instance, avoiding repeated lookups for this Managed Bean
- **Optimize counters map handling inside the `TimingSession` class:**
  - Remove bad usage of `Map.containsKey(String)` which caused the same key to be searched twice during the `getCounter(Type)` operation
- Extract a common method for some duplicate code found inside `DurationUtils`
