### PR TITLE
Fix issue #79 (negative duration/elapsed time)

### DIFF
--- a/src/main/java/net/obvj/performetrics/Counter.java
+++ b/src/main/java/net/obvj/performetrics/Counter.java
@@ -275,8 +275,13 @@ public class Counter
      */
     private long elapsedTimeNanos()
     {
+        // Let the "units after" be the current time if the actual "units after" were not set
         long tempUnitsAfter = unitsAfterSet ? unitsAfter : type.getTime();
-        return tempUnitsAfter >= unitsBefore ? tempUnitsAfter - unitsBefore : -1;
+
+        // IMPORTANT: Although thread CPU time has nanoseconds precision, it is not 100# accurate,
+        // which means that sometimes the units before may be greater than the units after.
+        // In cases like this, it is better to return zero.
+        return tempUnitsAfter >= unitsBefore ? tempUnitsAfter - unitsBefore : 0;
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/util/Duration.java
+++ b/src/main/java/net/obvj/performetrics/util/Duration.java
@@ -115,8 +115,8 @@ public final class Duration implements Comparable<Duration>
      * duration.getNanoseconds() //returns: 0
      * </pre>
      *
-     * @param amount       the amount of the duration, measured in terms of the time unit
-     *                     argument (negative is allowed)
+     * @param amount       the amount of the duration (positive or negative), measured in
+     *                     terms of the time unit argument
      * @param temporalUnit the unit that the amount argument is measured in, not null
      * @return a {@code Duration}, not null
      *

--- a/src/main/java/net/obvj/performetrics/util/Duration.java
+++ b/src/main/java/net/obvj/performetrics/util/Duration.java
@@ -59,7 +59,6 @@ public final class Duration implements Comparable<Duration>
     private static final String MSG_SOURCE_TIME_UNIT_MUST_NOT_BE_NULL = "The source TimeUnit must not be null";
     private static final String MSG_TARGET_TIME_UNIT_MUST_NOT_BE_NULL = "The target TimeUnit must not be null";
     private static final String MSG_FORMAT_MUST_NOT_BE_NULL = "The format must not be null";
-    private static final String MSG_AMOUNT_MUST_BE_POSITIVE = "The duration amount must be a positive value";
 
     private static final int SECONDS_PER_MINUTE = 60;
     private static final int SECONDS_PER_HOUR = 60 * 60;
@@ -89,13 +88,12 @@ public final class Duration implements Comparable<Duration>
      * duration.getNanoseconds() //returns: 0
      * </pre>
      *
-     * @param amount   the amount of the duration, measured in terms of the time unit
-     *                 argument, not negative
+     * @param amount   the amount of the duration (positive or negative), measured in terms of
+     *                 the time unit argument
      * @param timeUnit the unit that the amount argument is measured in, not null
      * @return a {@code Duration}, not null
      *
-     * @throws NullPointerException     if the specified time unit is null
-     * @throws IllegalArgumentException if the specified duration amount is negative
+     * @throws NullPointerException if the specified time unit is null
      */
     public static Duration of(long amount, TimeUnit timeUnit)
     {
@@ -118,7 +116,7 @@ public final class Duration implements Comparable<Duration>
      * </pre>
      *
      * @param amount       the amount of the duration, measured in terms of the time unit
-     *                     argument, not negative
+     *                     argument (negative is allowed)
      * @param temporalUnit the unit that the amount argument is measured in, not null
      * @return a {@code Duration}, not null
      *
@@ -128,10 +126,6 @@ public final class Duration implements Comparable<Duration>
      */
     public static Duration of(long amount, TemporalUnit temporalUnit)
     {
-        if (amount < 0)
-        {
-            throw new IllegalArgumentException(MSG_AMOUNT_MUST_BE_POSITIVE);
-        }
         java.time.Duration internalDuration = java.time.Duration.of(amount, temporalUnit);
         return new Duration(internalDuration);
     }
@@ -334,11 +328,11 @@ public final class Duration implements Comparable<Duration>
     {
         Objects.requireNonNull(timeUnit, MSG_TARGET_TIME_UNIT_MUST_NOT_BE_NULL);
 
-        BigDecimal targetSeconds = internalDuration.getSeconds() > 0
+        BigDecimal targetSeconds = internalDuration.getSeconds() != 0
                 ? BigDecimal.valueOf(timeUnit.convert(internalDuration.getSeconds(), TimeUnit.SECONDS))
                 : BigDecimal.ZERO;
 
-        BigDecimal targetNanoseconds = internalDuration.getNano() > 0
+        BigDecimal targetNanoseconds = internalDuration.getNano() != 0
                 ? convertNanosecondsPart(timeUnit, scale)
                 : BigDecimal.ZERO;
 
@@ -389,7 +383,8 @@ public final class Duration implements Comparable<Duration>
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param amount   the amount to add, measured in terms of the timeUnit argument
+     * @param amount   the amount to add (positive or negative), measured in terms of the
+     *                 timeUnit argument
      * @param timeUnit the unit that the amount to add is measured in, not null
      *
      * @return a {@code Duration} based on this duration with the specified duration added,

--- a/src/main/java/net/obvj/performetrics/util/DurationFormat.java
+++ b/src/main/java/net/obvj/performetrics/util/DurationFormat.java
@@ -81,11 +81,11 @@ public enum DurationFormat
         @Override
         public String doFormat(final Duration duration, boolean printLegend)
         {
-            if (duration.getHours() > 0)
+            if (duration.getHours() != 0)
             {
                 return DurationFormat.FULL.doFormat(duration, printLegend);
             }
-            if (duration.getMinutes() > 0)
+            if (duration.getMinutes() != 0)
             {
                 return String.format(MyTimeUnit.MINUTES.format, duration.getMinutes(),
                         duration.getSeconds(), duration.getNanoseconds())
@@ -126,11 +126,11 @@ public enum DurationFormat
             {
                 return format;
             }
-            if (duration.getHours() > 0)
+            if (duration.getHours() != 0)
             {
                 return format + legend(true, MyTimeUnit.HOURS.legend);
             }
-            if (duration.getMinutes() > 0)
+            if (duration.getMinutes() != 0)
             {
                 return format + legend(true, MyTimeUnit.MINUTES.legend);
             }
@@ -245,10 +245,10 @@ public enum DurationFormat
      * The pattern for parsing durations in the format {@code [H:][M:]S[.ns]}.
      */
     private static final Pattern HMS_PATTERN = Pattern.compile(
-            "^(((?<hours>\\d*):)?"
-            + "((?<minutes>\\d*):))?"
-            + "(?<seconds>\\d+)"
-            + "([.,](?<nanoseconds>\\d+))?"
+            "^(((?<hours>-?\\d*):)?"
+            + "((?<minutes>-?\\d*):))?"
+            + "(?<seconds>-?\\d+)"
+            + "([.,](?<nanoseconds>-?\\d+))?"
             + "(.)*"); // legend
 
     static final String MSG_DURATION_MUST_NOT_BE_NULL = "The duration must not be null";

--- a/src/test/java/net/obvj/performetrics/CounterTest.java
+++ b/src/test/java/net/obvj/performetrics/CounterTest.java
@@ -18,7 +18,6 @@ package net.obvj.performetrics;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static net.obvj.junit.utils.matchers.AdvancedMatchers.throwsException;
 import static net.obvj.performetrics.ConversionMode.DOUBLE_PRECISION;
 import static net.obvj.performetrics.ConversionMode.FAST;
 import static net.obvj.performetrics.Counter.Type.CPU_TIME;
@@ -111,13 +110,12 @@ class CounterTest
     }
 
     @Test
-    void elapsedTime_unitsAfterLowerThanUnitsBefore_negative1()
+    void elapsedTime_unitsAfterLowerThanUnitsBefore_zero()
     {
         Counter counter = new Counter(WALL_CLOCK_TIME);
         counter.setUnitsBefore(5_000);
         counter.setUnitsAfter(500);
-        assertThat(() -> counter.elapsedTime(), throwsException(IllegalArgumentException.class)
-                .withMessage("The duration amount must be a positive value"));
+        assertThat(counter.elapsedTime(), is(equalTo(Duration.ZERO)));
     }
 
     @Test

--- a/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
@@ -34,6 +34,7 @@ import net.obvj.performetrics.monitors.MonitoredCallable;
 import net.obvj.performetrics.monitors.MonitoredRunnable;
 import net.obvj.performetrics.util.Duration;
 import net.obvj.performetrics.util.DurationFormat;
+import net.obvj.performetrics.util.DurationUtils;
 import net.obvj.performetrics.util.print.PrintStyle;
 
 public class PerformetricsTestDrive
@@ -189,8 +190,12 @@ public class PerformetricsTestDrive
     private static void loadTest()
     {
         System.out.println("[main] Starting load test...");
+
+        int repeatTimes = 1_000_000;
         Map<Double, AtomicInteger> amounts = new HashMap<>();
-        for (int i = 0; i < 1_000_000; i++)
+        List<Duration> durations = new ArrayList<>(repeatTimes);
+
+        for (int i = 0; i < repeatTimes; i++)
         {
             MonitoredRunnable runnable = Performetrics.monitorOperation(() -> factorial(100L),
                     WALL_CLOCK_TIME, USER_TIME, SYSTEM_TIME);
@@ -198,10 +203,15 @@ public class PerformetricsTestDrive
             runnable.elapsedTime(USER_TIME);
             Duration st = runnable.elapsedTime(SYSTEM_TIME);
 
+            durations.add(st);
             amounts.computeIfAbsent(st.toSeconds(), k -> new AtomicInteger(0)).incrementAndGet();
         }
 
         System.out.println("[main] Load test finished");
+
+        System.out.print("[main] Computing average of elapsed SYSTEM_TIME... ");
+        System.out.println(DurationUtils.average(durations));
+
         System.out.println(amounts);
     }
 

--- a/src/test/java/net/obvj/performetrics/util/DurationTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationTest.java
@@ -60,9 +60,11 @@ class DurationTest
     @Test
     void of_negativeAmount_illegalArgumentException()
     {
-        assertThat(() -> Duration.of(-1, NANOSECONDS),
-                throwsException(IllegalArgumentException.class)
-                        .withMessage("The duration amount must be a positive value"));
+        Duration d1 = Duration.of(-1, SECONDS);
+        assertThat(d1.getHours(),       is(equalTo(0L)));
+        assertThat(d1.getMinutes(),     is(equalTo(0)));
+        assertThat(d1.getSeconds(),     is(equalTo(-1)));
+        assertThat(d1.getNanoseconds(), is(equalTo(0)));
     }
 
     @Test
@@ -89,6 +91,11 @@ class DurationTest
         assertThat(Duration.of(3601,       MINUTES     ).toSeconds(), is(equalTo(     216060D)));
         assertThat(Duration.of(2,          HOURS       ).toSeconds(), is(equalTo(       7200D)));
         assertThat(Duration.of(100,        HOURS       ).toSeconds(), is(equalTo(     360000D)));
+
+        // Tests with negative durations
+        assertThat(Duration.of(-1,          HOURS      ).toSeconds(), is(equalTo(       -3600D)));
+        assertThat(Duration.of(-1000000000, NANOSECONDS).toSeconds(), is(equalTo(          -1D)));
+        assertThat(Duration.of(-1000000001, NANOSECONDS).toSeconds(), is(equalTo(-1.000000001D)));
     }
 
     @Test
@@ -115,6 +122,11 @@ class DurationTest
         assertThat(Duration.of(3601,       MINUTES     ).toTimeUnit(MILLISECONDS), is(equalTo(  216060000D)));
         assertThat(Duration.of(2,          HOURS       ).toTimeUnit(MILLISECONDS), is(equalTo(    7200000D)));
         assertThat(Duration.of(100,        HOURS       ).toTimeUnit(MILLISECONDS), is(equalTo(  360000000D)));
+
+        // Tests with negative durations
+        assertThat(Duration.of(-1,          HOURS      ).toTimeUnit(MILLISECONDS), is(equalTo(    -3600000D)));
+        assertThat(Duration.of(-1000000000, NANOSECONDS).toTimeUnit(MILLISECONDS), is(equalTo(       -1000D)));
+        assertThat(Duration.of(-1000000001, NANOSECONDS).toTimeUnit(MILLISECONDS), is(equalTo(-1000.000001D)));
     }
 
     @Test
@@ -141,6 +153,11 @@ class DurationTest
         assertThat(Duration.of(3601,       MINUTES     ).toTimeUnit(MILLISECONDS, 3), is(equalTo(  216060000D)));
         assertThat(Duration.of(2,          HOURS       ).toTimeUnit(MILLISECONDS, 3), is(equalTo(    7200000D)));
         assertThat(Duration.of(100,        HOURS       ).toTimeUnit(MILLISECONDS, 3), is(equalTo(  360000000D)));
+
+        // Tests with negative durations
+        assertThat(Duration.of(-1,          HOURS      ).toTimeUnit(MILLISECONDS, 3), is(equalTo(-3600000D)));
+        assertThat(Duration.of(-1000000000, NANOSECONDS).toTimeUnit(MILLISECONDS, 3), is(equalTo(   -1000D)));
+        assertThat(Duration.of(-1000000001, NANOSECONDS).toTimeUnit(MILLISECONDS, 3), is(equalTo(   -1000D)));
     }
 
     @Test
@@ -207,6 +224,10 @@ class DurationTest
         assertThat(Duration.of(1800, SECONDS     ).plus(Duration.of(1800, SECONDS     )), is(equalTo(Duration.of(1, HOURS))));
         assertThat(Duration.of(3599, SECONDS     ).plus(Duration.of(3601, SECONDS     )), is(equalTo(Duration.of(2, HOURS))));
         assertThat(Duration.of( 500, MILLISECONDS).plus(Duration.of( 500, MILLISECONDS)), is(equalTo(Duration.of(1, SECONDS))));
+
+        // Tests with negative durations
+        assertThat(Duration.of( 500, MILLISECONDS).plus(Duration.of(-500, MILLISECONDS)), is(equalTo(Duration.of(0, NANOSECONDS))));
+        assertThat(Duration.of(2000, MILLISECONDS).plus(Duration.of(  -1, SECONDS     )), is(equalTo(Duration.of(1, SECONDS))));
     }
 
     @Test
@@ -216,14 +237,19 @@ class DurationTest
         assertThat(Duration.of(1800, SECONDS     ).plus(1800, SECONDS     ), is(equalTo(Duration.of(1, HOURS))));
         assertThat(Duration.of(3599, SECONDS     ).plus(3601, SECONDS     ), is(equalTo(Duration.of(2, HOURS))));
         assertThat(Duration.of( 500, MILLISECONDS).plus( 500, MILLISECONDS), is(equalTo(Duration.of(1, SECONDS))));
+
+        // Tests with negative durations
+        assertThat(Duration.of( 500, MILLISECONDS).plus(-500, MILLISECONDS), is(equalTo(Duration.of(0, NANOSECONDS))));
+        assertThat(Duration.of(2000, MILLISECONDS).plus(  -1, SECONDS     ), is(equalTo(Duration.of(1, SECONDS))));
     }
 
     @Test
     void dividedBy_positiveDivisor_success()
     {
-        assertThat(Duration.of(   2, HOURS       ).dividedBy(2), is(equalTo(Duration.of(  1, HOURS))));
-        assertThat(Duration.of(   3, HOURS       ).dividedBy(2), is(equalTo(Duration.of( 90, MINUTES))));
-        assertThat(Duration.of(1000, MILLISECONDS).dividedBy(5), is(equalTo(Duration.of(200, MILLISECONDS))));
+        assertThat(Duration.of(    2, HOURS       ).dividedBy(2), is(equalTo(Duration.of(   1, HOURS))));
+        assertThat(Duration.of(    3, HOURS       ).dividedBy(2), is(equalTo(Duration.of(  90, MINUTES))));
+        assertThat(Duration.of( 1000, MILLISECONDS).dividedBy(5), is(equalTo(Duration.of( 200, MILLISECONDS))));
+        assertThat(Duration.of(-1000, MILLISECONDS).dividedBy(5), is(equalTo(Duration.of(-200, MILLISECONDS))));
     }
 
     @Test
@@ -235,9 +261,10 @@ class DurationTest
     @Test
     void isZero_validDurations_success()
     {
-        assertThat(Duration.of(0, HOURS       ).isZero(), is(true));
-        assertThat(Duration.of(0, MILLISECONDS).isZero(), is(true));
-        assertThat(Duration.of(1, NANOSECONDS ).isZero(), is(false));
+        assertThat(Duration.of( 0, HOURS       ).isZero(), is(true));
+        assertThat(Duration.of( 0, MILLISECONDS).isZero(), is(true));
+        assertThat(Duration.of( 1, NANOSECONDS ).isZero(), is(false));
+        assertThat(Duration.of(-1, NANOSECONDS ).isZero(), is(false));
     }
 
     @Test
@@ -252,6 +279,7 @@ class DurationTest
     {
         assertThat(Duration.of(  1, SECONDS    ).compareTo(Duration.of(750, MILLISECONDS)), isPositive());
         assertThat(Duration.of(100, NANOSECONDS).compareTo(Duration.of( 20, NANOSECONDS )), isPositive());
+        assertThat(Duration.of(  0, NANOSECONDS).compareTo(Duration.of( -2, NANOSECONDS )), isPositive());
     }
 
     @Test
@@ -259,6 +287,7 @@ class DurationTest
     {
         assertThat(Duration.of( 1, MILLISECONDS).compareTo(Duration.of(2000000, NANOSECONDS)), isNegative());
         assertThat(Duration.of(40, MINUTES     ).compareTo(Duration.of(      1, HOURS      )), isNegative());
+        assertThat(Duration.of(-4, MINUTES     ).compareTo(Duration.of(     -3, MINUTES    )), isNegative());
     }
 
     @Test


### PR DESCRIPTION
This PR solves the bug #79.

I could reproduce the trouble creating a `MonitoredRunnable` that executes a simple and fast runnable **1 million times** (the average duration for the SYSTEM_TIME counter was 0.000002312 seconds).

During the analysis, I realized that, in some (frequent) cases, the nanoseconds after the operation were populated with an amount that was lower than the value retrieved before the operation, due to a known accuracy issue inside JDK's `ThreadMXBean`.

According to the JDK 17 Javadoc: "The CPU time provided is of nanoseconds precision but not necessarily nanoseconds accuracy" (https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/ThreadMXBean.html).

So, to avoid the negative elapsed time, I implemented the following fixes:

- [X] The `Counter.elapsedTimeNanos()` was modified to return zero (instead of -1) when the time retrieved after the operation is lower than the one retrieved before the operation
- [X] The `Duration` class now also allows negative amounts, to prevent the issue from happening in another situation (for example, if CPU time is not supported by the JVM)

The fix was validated with JUnit and a new stress test method at the `PerformetricsTestDrive` class.

✅ The fix will be released in Performetrics version 2.5.2.