### PR TITLE
Fix formatting and parsing of negative durations

### DIFF
--- a/src/main/java/net/obvj/performetrics/util/Duration.java
+++ b/src/main/java/net/obvj/performetrics/util/Duration.java
@@ -64,9 +64,9 @@ public final class Duration implements Comparable<Duration>
     private static final int SECONDS_PER_HOUR = 60 * 60;
     private static final long NANOS_PER_SECOND = 1000_000_000L;
 
-    private final java.time.Duration internalDuration;
-    private final long effectiveTotalSeconds;
-    private final int effectiveNanoseconds;
+    final java.time.Duration internalDuration;
+    final long effectiveTotalSeconds;
+    final int effectiveNanoseconds;
 
     /**
      * Constructs an instance of {@code Duration} from the given {@link java.time.Duration}.

--- a/src/main/java/net/obvj/performetrics/util/Duration.java
+++ b/src/main/java/net/obvj/performetrics/util/Duration.java
@@ -167,8 +167,7 @@ public final class Duration implements Comparable<Duration>
      * @param temporalUnit the unit that the amount argument is measured in, not null
      * @return a {@code Duration}, not null
      *
-     * @throws NullPointerException     if the specified time unit is null
-     * @throws IllegalArgumentException if the specified duration amount is negative
+     * @throws NullPointerException if the specified time unit is null
      * @since 2.5.0
      */
     public static Duration of(long amount, TemporalUnit temporalUnit)
@@ -477,20 +476,53 @@ public final class Duration implements Comparable<Duration>
     }
 
     /**
+     * Returns a copy of this duration multiplied by the scalar.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param multiplicand the value to multiply the duration by, positive or negative
+     * @return a {@code Duration} based on this duration multiplied by the specified scalar,
+     *         not null
+     * @throws ArithmeticException if numeric overflow occurs
+     * @since 2.5.3
+     */
+    public Duration multipliedBy(long multiplicand)
+    {
+        return new Duration(internalDuration.multipliedBy(multiplicand));
+    }
+
+    /**
      * Returns a copy of this duration divided by the specified value.
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
      * @param divisor the value to divide the duration by, positive or negative, not zero
-     * @return a Duration based on this duration divided by the specified divisor, not null
+     * @return a {@code Duration} based on this duration divided by the specified divisor, not
+     *         null
      *
      * @throws ArithmeticException if the divisor is zero or if numeric overflow occurs
-     *
      * @since 2.2.0
      */
     public Duration dividedBy(long divisor)
     {
         return new Duration(internalDuration.dividedBy(divisor));
+    }
+
+    /**
+     * Returns a copy of this duration with the length negated.
+     * <p>
+     * This method swaps the sign of the total length of this duration. For example,
+     * {@code 1.3 second(s)} will be returned as {@code -1.3 second(s)}.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @return a {@code Duration} based on this duration with the amount negated, not null
+     * @throws ArithmeticException if numeric overflow occurs
+     * @since 2.5.3
+     */
+    public Duration negated()
+    {
+        return multipliedBy(-1);
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/util/Duration.java
+++ b/src/main/java/net/obvj/performetrics/util/Duration.java
@@ -62,8 +62,11 @@ public final class Duration implements Comparable<Duration>
 
     private static final int SECONDS_PER_MINUTE = 60;
     private static final int SECONDS_PER_HOUR = 60 * 60;
+    private static final long NANOS_PER_SECOND = 1000_000_000L;
 
     private final java.time.Duration internalDuration;
+    private final long effectiveTotalSeconds;
+    private final int effectiveNanoseconds;
 
     /**
      * Constructs an instance of {@code Duration} from the given {@link java.time.Duration}.
@@ -73,6 +76,50 @@ public final class Duration implements Comparable<Duration>
     Duration(java.time.Duration internalDuration)
     {
         this.internalDuration = Objects.requireNonNull(internalDuration);
+        effectiveTotalSeconds = effectiveTotalSeconds(internalDuration);
+        effectiveNanoseconds = (int) effectiveNanoseconds(internalDuration);
+    }
+
+    /**
+     * Calculates and returns the effective total seconds from the given duration, i.e., a
+     * positive number that represents the total of seconds (without the nanoseconds) inside
+     * the duration, regardless if the duration length is positive or not.
+     *
+     * @param internalDuration the {@link java.time.Duration} to be checked
+     * @return the effective total seconds as {@code long}
+     * @since 2.5.3
+     */
+    private static long effectiveTotalSeconds(java.time.Duration internalDuration)
+    {
+        long effectiveTotalSeconds = internalDuration.getSeconds();
+        if (internalDuration.isNegative())
+        {
+            if (internalDuration.getNano() > 0)
+            {
+                effectiveTotalSeconds++;
+            }
+            return -effectiveTotalSeconds;
+        }
+        return effectiveTotalSeconds;
+    }
+
+    /**
+     * Calculates and returns the effective nanoseconds from the given duration, i.e., a
+     * positive number that represents the nanoseconds part (without the seconds) inside the
+     * duration, regardless if the duration length is positive or not.
+     *
+     * @param internalDuration the {@link java.time.Duration} to be checked
+     * @return the effective nanoseconds as {@code int}
+     * @since 2.5.3
+     */
+    private static long effectiveNanoseconds(java.time.Duration internalDuration)
+    {
+        int nanos = internalDuration.getNano();
+        if (nanos > 0 && internalDuration.isNegative())
+        {
+            return NANOS_PER_SECOND - nanos;
+        }
+        return nanos;
     }
 
     /**
@@ -177,7 +224,7 @@ public final class Duration implements Comparable<Duration>
      */
     public long getHours()
     {
-        return internalDuration.getSeconds() / SECONDS_PER_HOUR;
+        return effectiveTotalSeconds / SECONDS_PER_HOUR;
     }
 
     /**
@@ -190,7 +237,7 @@ public final class Duration implements Comparable<Duration>
      */
     public int getMinutes()
     {
-        return (int) ((internalDuration.getSeconds() % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+        return (int) ((effectiveTotalSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
     }
 
     /**
@@ -204,7 +251,7 @@ public final class Duration implements Comparable<Duration>
      */
     public int getSeconds()
     {
-        return (int) (internalDuration.getSeconds() % SECONDS_PER_MINUTE);
+        return (int) (effectiveTotalSeconds % SECONDS_PER_MINUTE);
     }
 
     /**
@@ -219,7 +266,7 @@ public final class Duration implements Comparable<Duration>
      */
     public int getNanoseconds()
     {
-        return internalDuration.getNano();
+        return effectiveNanoseconds;
     }
 
     /**
@@ -231,6 +278,17 @@ public final class Duration implements Comparable<Duration>
     public boolean isZero()
     {
         return internalDuration.isZero();
+    }
+
+    /**
+     * Checks if this duration is negative, excluding zero.
+     *
+     * @return true if this duration has a total length less than zero
+     * @since 2.5.3
+     */
+    public boolean isNegative()
+    {
+        return internalDuration.isNegative();
     }
 
     @Override
@@ -328,23 +386,23 @@ public final class Duration implements Comparable<Duration>
     {
         Objects.requireNonNull(timeUnit, MSG_TARGET_TIME_UNIT_MUST_NOT_BE_NULL);
 
-        BigDecimal targetSeconds = internalDuration.getSeconds() != 0
-                ? BigDecimal.valueOf(timeUnit.convert(internalDuration.getSeconds(), TimeUnit.SECONDS))
+        BigDecimal targetSeconds = effectiveTotalSeconds != 0
+                ? BigDecimal.valueOf(timeUnit.convert(effectiveTotalSeconds, TimeUnit.SECONDS))
                 : BigDecimal.ZERO;
 
-        BigDecimal targetNanoseconds = internalDuration.getNano() != 0
+        BigDecimal targetNanoseconds = effectiveNanoseconds != 0
                 ? convertNanosecondsPart(timeUnit, scale)
                 : BigDecimal.ZERO;
 
-        return targetSeconds.add(targetNanoseconds).doubleValue();
+        double absoluteResult = targetSeconds.add(targetNanoseconds).doubleValue();
+        return isNegative() ? -absoluteResult : absoluteResult;
     }
 
     private BigDecimal convertNanosecondsPart(TimeUnit timeUnit, int scale)
     {
-        int nanoseconds = internalDuration.getNano();
         return scale >= 0
-                ? BigDecimal.valueOf(TimeUnitConverter.convertAndRound(nanoseconds, TimeUnit.NANOSECONDS, timeUnit, scale))
-                : BigDecimal.valueOf(TimeUnitConverter.convertAndRound(nanoseconds, TimeUnit.NANOSECONDS, timeUnit));
+                ? BigDecimal.valueOf(TimeUnitConverter.convertAndRound(effectiveNanoseconds, TimeUnit.NANOSECONDS, timeUnit, scale))
+                : BigDecimal.valueOf(TimeUnitConverter.convertAndRound(effectiveNanoseconds, TimeUnit.NANOSECONDS, timeUnit));
     }
 
     /**

--- a/src/main/java/net/obvj/performetrics/util/DurationFormat.java
+++ b/src/main/java/net/obvj/performetrics/util/DurationFormat.java
@@ -52,9 +52,21 @@ public enum DurationFormat
         @Override
         public String doFormat(final Duration duration, boolean printLegend)
         {
-            return String.format(MyTimeUnit.HOURS.format, duration.getHours(),
-                    duration.getMinutes(), duration.getSeconds(), duration.getNanoseconds())
-                    + legend(printLegend, MyTimeUnit.HOURS.legend);
+            StringBuilder buf = new StringBuilder(32);
+            if (duration.isNegative())
+            {
+                buf.append('-');
+            }
+
+            buf.append(String.format(MyTimeUnit.HOURS.format, duration.getHours(),
+                    duration.getMinutes(), duration.getSeconds(), duration.getNanoseconds()));
+
+            if (printLegend)
+            {
+                buf.append(' ').append(MyTimeUnit.HOURS.legend);
+            }
+
+            return buf.toString();
         }
 
         @Override
@@ -297,6 +309,7 @@ public enum DurationFormat
      * @param legend      the string to be used as legend
      * @return the legend string
      */
+    @Deprecated
     private static String legend(boolean printLegend, final String legend)
     {
         return printLegend ? " " + legend : "";

--- a/src/main/java/net/obvj/performetrics/util/DurationFormat.java
+++ b/src/main/java/net/obvj/performetrics/util/DurationFormat.java
@@ -52,21 +52,17 @@ public enum DurationFormat
         @Override
         public String doFormat(final Duration duration, boolean printLegend)
         {
-            StringBuilder buf = new StringBuilder(32);
+            StringBuilder buffer = new StringBuilder(32);
             if (duration.isNegative())
             {
-                buf.append('-');
+                buffer.append('-');
             }
 
-            buf.append(String.format(MyTimeUnit.HOURS.format, duration.getHours(),
+            buffer.append(String.format(MyTimeUnit.HOURS.format, duration.getHours(),
                     duration.getMinutes(), duration.getSeconds(), duration.getNanoseconds()));
 
-            if (printLegend)
-            {
-                buf.append(' ').append(MyTimeUnit.HOURS.legend);
-            }
-
-            return buf.toString();
+            appendlegend(buffer, printLegend, MyTimeUnit.HOURS);
+            return buffer.toString();
         }
 
         @Override
@@ -93,37 +89,31 @@ public enum DurationFormat
         @Override
         public String doFormat(final Duration duration, boolean printLegend)
         {
-            if (duration.getHours() != 0)
+            final MyTimeUnit timeUnit = MyTimeUnit.from(duration);
+            if (timeUnit == MyTimeUnit.HOURS)
             {
                 return DurationFormat.FULL.doFormat(duration, printLegend);
             }
 
-            StringBuilder buf = new StringBuilder(32);
+            StringBuilder buffer = new StringBuilder(32);
             if (duration.isNegative())
             {
-                buf.append('-');
+                buffer.append('-');
             }
 
-            MyTimeUnit timeUnit;
-            if (duration.getMinutes() != 0)
+            if (timeUnit == MyTimeUnit.MINUTES)
             {
-                timeUnit = MyTimeUnit.MINUTES;
-                buf.append(String.format(timeUnit.format, duration.getMinutes(),
+                buffer.append(String.format(timeUnit.format, duration.getMinutes(),
                         duration.getSeconds(), duration.getNanoseconds()));
             }
             else
             {
-                timeUnit = MyTimeUnit.SECONDS;
-                buf.append(String.format(timeUnit.format,
+                buffer.append(String.format(timeUnit.format,
                         duration.getSeconds(), duration.getNanoseconds()));
             }
 
-            if (printLegend)
-            {
-                buf.append(' ').append(timeUnit.legend);
-            }
-
-            return buf.toString();
+            appendlegend(buffer, printLegend, timeUnit);
+            return buffer.toString();
         }
 
         @Override
@@ -152,20 +142,7 @@ public enum DurationFormat
         public String doFormat(final Duration duration, boolean printLegend)
         {
             String format = removeTrailingZeros(SHORT.doFormat(duration, false));
-
-            if (!printLegend)
-            {
-                return format;
-            }
-            if (duration.getHours() != 0)
-            {
-                return format + legend(true, MyTimeUnit.HOURS.legend);
-            }
-            if (duration.getMinutes() != 0)
-            {
-                return format + legend(true, MyTimeUnit.MINUTES.legend);
-            }
-            return format + legend(true, MyTimeUnit.SECONDS.legend);
+            return printLegend ? format + ' ' + MyTimeUnit.from(duration).legend : format;
         }
 
         @Override
@@ -322,17 +299,19 @@ public enum DurationFormat
     abstract Duration doParse(final String string);
 
     /**
-     * Returns the {@code legend}, prepended with a white-space, if the
-     * {@code printLegendFlag} argument is {@code true}; or an empty string, otherwise.
+     * Appends the {@code legend}, prepended with a white-space, if the {@code printLegend}
+     * flag is {@code true}
      *
+     * @param buffer      the buffer to append to (not null)
      * @param printLegend the flag to be evaluated
-     * @param legend      the string to be used as legend
-     * @return the legend string
+     * @param timeUnit    the time unit
      */
-    @Deprecated
-    private static String legend(boolean printLegend, final String legend)
+    private static void appendlegend(StringBuilder buffer, boolean printLegend, final MyTimeUnit timeUnit)
     {
-        return printLegend ? " " + legend : "";
+        if (printLegend)
+        {
+            buffer.append(' ').append(timeUnit.legend);
+        }
     }
 
     /**
@@ -469,6 +448,19 @@ public enum DurationFormat
         {
             this.legend = legend;
             this.format = format;
+        }
+
+        private static MyTimeUnit from(Duration duration)
+        {
+            if (duration.getHours() != 0)
+            {
+                return MyTimeUnit.HOURS;
+            }
+            if (duration.getMinutes() != 0)
+            {
+                return MyTimeUnit.MINUTES;
+            }
+            return MyTimeUnit.SECONDS;
         }
 
     }

--- a/src/test/java/net/obvj/performetrics/util/DurationFormatTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationFormatTest.java
@@ -216,6 +216,32 @@ class DurationFormatTest
         assertThat(LINUX.format(Duration.of(2,          HOURS       ), false), is(equalTo("120m0.000s")));
         assertThat(LINUX.format(Duration.of(100,        HOURS       ), false), is(equalTo("6000m0.000s")));
     }
+    
+    @Test
+    void format_linuxNegative()
+    {
+        assertThat(LINUX.format(Duration.of(-0,          NANOSECONDS ), false), is(equalTo("0m0.000s")));
+        assertThat(LINUX.format(Duration.of(-1,          NANOSECONDS ), false), is(equalTo("-0m0.000s")));
+        assertThat(LINUX.format(Duration.of(-1,          MILLISECONDS), false), is(equalTo("-0m0.001s")));
+        assertThat(LINUX.format(Duration.of(-1,          SECONDS     ), false), is(equalTo("-0m1.000s")));
+        assertThat(LINUX.format(Duration.of(-1,          MINUTES     ), false), is(equalTo("-1m0.000s")));
+        assertThat(LINUX.format(Duration.of(-1,          HOURS       ), false), is(equalTo("-60m0.000s")));
+        assertThat(LINUX.format(Duration.of(-1,          DAYS        ), false), is(equalTo("-1440m0.000s")));
+        assertThat(LINUX.format(Duration.of(-789,        NANOSECONDS ), false), is(equalTo("-0m0.000s")));
+        assertThat(LINUX.format(Duration.of(-123456789,  NANOSECONDS ), false), is(equalTo("-0m0.123s")));
+        assertThat(LINUX.format(Duration.of(-1000000000, NANOSECONDS ), false), is(equalTo("-0m1.000s")));
+        assertThat(LINUX.format(Duration.of(-1001,       MILLISECONDS), false), is(equalTo("-0m1.001s")));
+        assertThat(LINUX.format(Duration.of(-1601,       MILLISECONDS), false), is(equalTo("-0m1.601s")));
+        assertThat(LINUX.format(Duration.of(-3601,       MILLISECONDS), false), is(equalTo("-0m3.601s")));
+        assertThat(LINUX.format(Duration.of(-70,         SECONDS     ), false), is(equalTo("-1m10.000s")));
+        assertThat(LINUX.format(Duration.of(-601,        SECONDS     ), false), is(equalTo("-10m1.000s")));
+        assertThat(LINUX.format(Duration.of(-959,        SECONDS     ), false), is(equalTo("-15m59.000s")));
+        assertThat(LINUX.format(Duration.of(-960,        SECONDS     ), false), is(equalTo("-16m0.000s")));
+        assertThat(LINUX.format(Duration.of(-970,        SECONDS     ), false), is(equalTo("-16m10.000s")));
+        assertThat(LINUX.format(Duration.of(-3601,       MINUTES     ), false), is(equalTo("-3601m0.000s")));
+        assertThat(LINUX.format(Duration.of(-2,          HOURS       ), false), is(equalTo("-120m0.000s")));
+        assertThat(LINUX.format(Duration.of(-100,        HOURS       ), false), is(equalTo("-6000m0.000s")));
+    }
 
     @Test
     void toString_noArguments_appliesShorterStyleWithLegend()

--- a/src/test/java/net/obvj/performetrics/util/DurationFormatTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationFormatTest.java
@@ -61,6 +61,31 @@ class DurationFormatTest
         assertThat(FULL.format(Duration.of(2,          HOURS       ), false), is(equalTo(  "2:00:00.000000000")));
         assertThat(FULL.format(Duration.of(100,        HOURS       ), false), is(equalTo("100:00:00.000000000")));
     }
+    
+    @Test
+    void format_fullAndNegative_displaysAllUnits()
+    {
+        assertThat(FULL.format(Duration.of(-1,          NANOSECONDS ), false), is(equalTo(  "-0:00:00.000000001")));
+        assertThat(FULL.format(Duration.of(-1,          MILLISECONDS), false), is(equalTo(  "-0:00:00.001000000")));
+        assertThat(FULL.format(Duration.of(-1,          SECONDS     ), false), is(equalTo(  "-0:00:01.000000000")));
+        assertThat(FULL.format(Duration.of(-1,          MINUTES     ), false), is(equalTo(  "-0:01:00.000000000")));
+        assertThat(FULL.format(Duration.of(-1,          HOURS       ), false), is(equalTo(  "-1:00:00.000000000")));
+        assertThat(FULL.format(Duration.of(-1,          DAYS        ), false), is(equalTo( "-24:00:00.000000000")));
+        assertThat(FULL.format(Duration.of(-789,        NANOSECONDS ), false), is(equalTo(  "-0:00:00.000000789")));
+        assertThat(FULL.format(Duration.of(-123456789,  NANOSECONDS ), false), is(equalTo(  "-0:00:00.123456789")));
+        assertThat(FULL.format(Duration.of(-1000000000, NANOSECONDS ), false), is(equalTo(  "-0:00:01.000000000")));
+        assertThat(FULL.format(Duration.of(-1001,       MILLISECONDS), false), is(equalTo(  "-0:00:01.001000000")));
+        assertThat(FULL.format(Duration.of(-1601,       MILLISECONDS), false), is(equalTo(  "-0:00:01.601000000")));
+        assertThat(FULL.format(Duration.of(-3601,       MILLISECONDS), false), is(equalTo(  "-0:00:03.601000000")));
+        assertThat(FULL.format(Duration.of(-70,         SECONDS     ), false), is(equalTo(  "-0:01:10.000000000")));
+        assertThat(FULL.format(Duration.of(-601,        SECONDS     ), false), is(equalTo(  "-0:10:01.000000000")));
+        assertThat(FULL.format(Duration.of(-959,        SECONDS     ), false), is(equalTo(  "-0:15:59.000000000")));
+        assertThat(FULL.format(Duration.of(-960,        SECONDS     ), false), is(equalTo(  "-0:16:00.000000000")));
+        assertThat(FULL.format(Duration.of(-970,        SECONDS     ), false), is(equalTo(  "-0:16:10.000000000")));
+        assertThat(FULL.format(Duration.of(-3601,       MINUTES     ), false), is(equalTo( "-60:01:00.000000000")));
+        assertThat(FULL.format(Duration.of(-2,          HOURS       ), false), is(equalTo(  "-2:00:00.000000000")));
+        assertThat(FULL.format(Duration.of(-100,        HOURS       ), false), is(equalTo("-100:00:00.000000000")));
+    }
 
     @Test
     void format_short_abbreviatesIfPossible()

--- a/src/test/java/net/obvj/performetrics/util/DurationFormatTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationFormatTest.java
@@ -312,7 +312,7 @@ class DurationFormatTest
     }
 
     @Test
-    void parse_linux_success()
+    void parse_linuxPositive_success()
     {
         assertThat(LINUX.parse( "0m0.000s"), equalTo(Duration.ZERO));
         assertThat(LINUX.parse( "0m0.100s"), equalTo(Duration.of(100, MILLISECONDS)));
@@ -324,6 +324,20 @@ class DurationFormatTest
         assertThat(LINUX.parse("1m70.000s"), equalTo(Duration.of(130, SECONDS)));
     }
 
+    @Test
+    void parse_linuxNegative_success()
+    {
+        assertThat(LINUX.parse( "-0m0.000s"), equalTo(Duration.ZERO));
+        assertThat(LINUX.parse( "-0m0.100s"), equalTo(Duration.of(-100, MILLISECONDS)));
+        assertThat(LINUX.parse( "-0m1.000s"), equalTo(Duration.of(  -1, SECONDS)));
+        assertThat(LINUX.parse( "-1m1.000s"), equalTo(Duration.of( -61, SECONDS)));
+
+        // Field overflow is OK
+        assertThat(LINUX.parse("-0m1.1000s"), equalTo(Duration.of(  -2, SECONDS)));
+        assertThat(LINUX.parse("-1m70.000s"), equalTo(Duration.of(-130, SECONDS)));
+    }
+
+    
     @Test
     void parse_fullAndNull_nullPointerException()
     {

--- a/src/test/java/net/obvj/performetrics/util/DurationFormatTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationFormatTest.java
@@ -61,7 +61,7 @@ class DurationFormatTest
         assertThat(FULL.format(Duration.of(2,          HOURS       ), false), is(equalTo(  "2:00:00.000000000")));
         assertThat(FULL.format(Duration.of(100,        HOURS       ), false), is(equalTo("100:00:00.000000000")));
     }
-    
+
     @Test
     void format_fullAndNegative_displaysAllUnits()
     {
@@ -114,6 +114,32 @@ class DurationFormatTest
     }
 
     @Test
+    void format_shortAndNegative_abbreviatesIfPossible()
+    {
+        assertThat(SHORT.format(Duration.of(-0,          NANOSECONDS ), false), is(equalTo(          "0.000000000")));
+        assertThat(SHORT.format(Duration.of(-1,          NANOSECONDS ), false), is(equalTo(        "-0.000000001")));
+        assertThat(SHORT.format(Duration.of(-1,          MILLISECONDS), false), is(equalTo(        "-0.001000000")));
+        assertThat(SHORT.format(Duration.of(-1,          SECONDS     ), false), is(equalTo(        "-1.000000000")));
+        assertThat(SHORT.format(Duration.of(-1,          MINUTES     ), false), is(equalTo(     "-1:00.000000000")));
+        assertThat(SHORT.format(Duration.of(-1,          HOURS       ), false), is(equalTo(  "-1:00:00.000000000")));
+        assertThat(SHORT.format(Duration.of(-1,          DAYS        ), false), is(equalTo( "-24:00:00.000000000")));
+        assertThat(SHORT.format(Duration.of(-789,        NANOSECONDS ), false), is(equalTo(        "-0.000000789")));
+        assertThat(SHORT.format(Duration.of(-123456789,  NANOSECONDS ), false), is(equalTo(        "-0.123456789")));
+        assertThat(SHORT.format(Duration.of(-1000000000, NANOSECONDS ), false), is(equalTo(        "-1.000000000")));
+        assertThat(SHORT.format(Duration.of(-1001,       MILLISECONDS), false), is(equalTo(        "-1.001000000")));
+        assertThat(SHORT.format(Duration.of(-1601,       MILLISECONDS), false), is(equalTo(        "-1.601000000")));
+        assertThat(SHORT.format(Duration.of(-3601,       MILLISECONDS), false), is(equalTo(        "-3.601000000")));
+        assertThat(SHORT.format(Duration.of(-70,         SECONDS     ), false), is(equalTo(     "-1:10.000000000")));
+        assertThat(SHORT.format(Duration.of(-601,        SECONDS     ), false), is(equalTo(    "-10:01.000000000")));
+        assertThat(SHORT.format(Duration.of(-959,        SECONDS     ), false), is(equalTo(    "-15:59.000000000")));
+        assertThat(SHORT.format(Duration.of(-960,        SECONDS     ), false), is(equalTo(    "-16:00.000000000")));
+        assertThat(SHORT.format(Duration.of(-970,        SECONDS     ), false), is(equalTo(    "-16:10.000000000")));
+        assertThat(SHORT.format(Duration.of(-3601,       MINUTES     ), false), is(equalTo( "-60:01:00.000000000")));
+        assertThat(SHORT.format(Duration.of(-2,          HOURS       ), false), is(equalTo(  "-2:00:00.000000000")));
+        assertThat(SHORT.format(Duration.of(-100,        HOURS       ), false), is(equalTo("-100:00:00.000000000")));
+    }
+
+    @Test
     void format_shorterWithLegend_supressesTrailingZeros()
     {
         assertThat(SHORTER.format(Duration.of(0,          NANOSECONDS ), true), is(equalTo(          "0 second(s)")));
@@ -142,7 +168,7 @@ class DurationFormatTest
     @Test
     void format_shorterWithoutLegend_supressesTrailingZeros()
     {
-        assertThat(SHORTER.format(Duration.of(0,          NANOSECONDS ), false), is(equalTo("0")));
+        assertThat(SHORTER.format(Duration.of(0,          NANOSECONDS ), false), is(equalTo(          "0")));
         assertThat(SHORTER.format(Duration.of(1,          NANOSECONDS ), false), is(equalTo("0.000000001")));
         assertThat(SHORTER.format(Duration.of(1,          MILLISECONDS), false), is(equalTo(      "0.001")));
         assertThat(SHORTER.format(Duration.of(1,          SECONDS     ), false), is(equalTo(          "1")));
@@ -163,6 +189,32 @@ class DurationFormatTest
         assertThat(SHORTER.format(Duration.of(3601,       MINUTES     ), false), is(equalTo(   "60:01:00")));
         assertThat(SHORTER.format(Duration.of(2,          HOURS       ), false), is(equalTo(    "2:00:00")));
         assertThat(SHORTER.format(Duration.of(100,        HOURS       ), false), is(equalTo(  "100:00:00")));
+    }
+
+    @Test
+    void format_shorterWithoutLegendAndNegative_supressesTrailingZeros()
+    {
+        assertThat(SHORTER.format(Duration.of(-0,          NANOSECONDS ), false), is(equalTo(           "0")));
+        assertThat(SHORTER.format(Duration.of(-1,          NANOSECONDS ), false), is(equalTo("-0.000000001")));
+        assertThat(SHORTER.format(Duration.of(-1,          MILLISECONDS), false), is(equalTo(      "-0.001")));
+        assertThat(SHORTER.format(Duration.of(-1,          SECONDS     ), false), is(equalTo(          "-1")));
+        assertThat(SHORTER.format(Duration.of(-1,          MINUTES     ), false), is(equalTo(       "-1:00")));
+        assertThat(SHORTER.format(Duration.of(-1,          HOURS       ), false), is(equalTo(    "-1:00:00")));
+        assertThat(SHORTER.format(Duration.of(-1,          DAYS        ), false), is(equalTo(   "-24:00:00")));
+        assertThat(SHORTER.format(Duration.of(-789,        NANOSECONDS ), false), is(equalTo("-0.000000789")));
+        assertThat(SHORTER.format(Duration.of(-123456789,  NANOSECONDS ), false), is(equalTo("-0.123456789")));
+        assertThat(SHORTER.format(Duration.of(-1000000000, NANOSECONDS ), false), is(equalTo(          "-1")));
+        assertThat(SHORTER.format(Duration.of(-1001,       MILLISECONDS), false), is(equalTo(      "-1.001")));
+        assertThat(SHORTER.format(Duration.of(-1601,       MILLISECONDS), false), is(equalTo(      "-1.601")));
+        assertThat(SHORTER.format(Duration.of(-3601,       MILLISECONDS), false), is(equalTo(      "-3.601")));
+        assertThat(SHORTER.format(Duration.of(-70,         SECONDS     ), false), is(equalTo(       "-1:10")));
+        assertThat(SHORTER.format(Duration.of(-601,        SECONDS     ), false), is(equalTo(      "-10:01")));
+        assertThat(SHORTER.format(Duration.of(-959,        SECONDS     ), false), is(equalTo(      "-15:59")));
+        assertThat(SHORTER.format(Duration.of(-960,        SECONDS     ), false), is(equalTo(      "-16:00")));
+        assertThat(SHORTER.format(Duration.of(-970,        SECONDS     ), false), is(equalTo(      "-16:10")));
+        assertThat(SHORTER.format(Duration.of(-3601,       MINUTES     ), false), is(equalTo(   "-60:01:00")));
+        assertThat(SHORTER.format(Duration.of(-2,          HOURS       ), false), is(equalTo(    "-2:00:00")));
+        assertThat(SHORTER.format(Duration.of(-100,        HOURS       ), false), is(equalTo(  "-100:00:00")));
     }
 
     @Test
@@ -216,7 +268,7 @@ class DurationFormatTest
         assertThat(LINUX.format(Duration.of(2,          HOURS       ), false), is(equalTo("120m0.000s")));
         assertThat(LINUX.format(Duration.of(100,        HOURS       ), false), is(equalTo("6000m0.000s")));
     }
-    
+
     @Test
     void format_linuxNegative()
     {
@@ -250,6 +302,12 @@ class DurationFormatTest
     }
 
     @Test
+    void toString_noArgumentsAndNegative_appliesShorterStyleWithLegend()
+    {
+        assertThat(Duration.of(-3602, MILLISECONDS).toString(), is(equalTo("-3.602 second(s)")));
+    }
+
+    @Test
     void toString_full_appliesFullStyleWithLegend()
     {
         assertThat(Duration.of(3601, MILLISECONDS).toString(FULL),
@@ -257,11 +315,19 @@ class DurationFormatTest
     }
 
     @Test
+    void toString_fullAndNegative_appliesFullStyleWithLegend()
+    {
+        assertThat(Duration.of(-3601, MILLISECONDS).toString(FULL),
+                is(equalTo("-0:00:03.601000000 hour(s)")));
+    }
+
+    @Test
     void removeTrailingZeros_validStrings_success()
     {
-        assertThat(removeTrailingZeros("9.009000000"), is(equalTo("9.009")));
-        assertThat(removeTrailingZeros("9.000000009"), is(equalTo("9.000000009")));
-        assertThat(removeTrailingZeros("9.000000000"), is(equalTo("9")));
+        assertThat(removeTrailingZeros( "9.009000000"), is(equalTo("9.009")));
+        assertThat(removeTrailingZeros( "9.000000009"), is(equalTo("9.000000009")));
+        assertThat(removeTrailingZeros( "9.000000000"), is(equalTo("9")));
+        assertThat(removeTrailingZeros("-9.000000000"), is(equalTo("-9")));
     }
 
     @Test
@@ -281,6 +347,22 @@ class DurationFormatTest
     }
 
     @Test
+    void parse_fullAndValidStringButNegative_success()
+    {
+        assertThat(FULL.parse("-00:00:00.000000000"), equalTo(Duration.ZERO));
+        assertThat(FULL.parse("-00:00:00.100000000"), equalTo(Duration.of(    -100, MILLISECONDS)));
+        assertThat(FULL.parse("-00:00:01.000000000"), equalTo(Duration.of(      -1, SECONDS)));
+        assertThat(FULL.parse("-00:01:01.000000000"), equalTo(Duration.of(     -61, SECONDS)));
+        assertThat(FULL.parse("-01:01:00.000000000"), equalTo(Duration.of(     -61, MINUTES)));
+        assertThat(FULL.parse("-01:01:01.000000000"), equalTo(Duration.of(   -3661, SECONDS)));
+        assertThat(FULL.parse("-01:01:01.100000000"), equalTo(Duration.of(-3661100, MILLISECONDS)));
+
+        // Field overflow is OK
+        assertThat(FULL.parse("-00:01:70.000000000"), equalTo(Duration.of(-130, SECONDS)));
+        assertThat(FULL.parse("-01:60:00.000000000"), equalTo(Duration.of(  -2, HOURS)));
+    }
+
+    @Test
     void parse_shortAndValidString_success()
     {
         assertThat(SHORT.parse(       "0.000000000 second(s)"), equalTo(Duration.ZERO));
@@ -294,6 +376,22 @@ class DurationFormatTest
         assertThat(SHORT.parse(   "1:30.000000000"), equalTo(Duration.of(  90, SECONDS)));
         assertThat(SHORT.parse("1:30:00.000000000"), equalTo(Duration.of(  90, MINUTES)));    }
 
+    @Test
+    void parse_shortAndValidStringNegative_success()
+    {
+        assertThat(SHORT.parse(       "-0.000000000 second(s)"), equalTo(Duration.ZERO));
+        assertThat(SHORT.parse(       "-0.100000000 second(s)"), equalTo(Duration.of( -100, MILLISECONDS)));
+        assertThat(SHORT.parse(       "-1.000000000 second(s)"), equalTo(Duration.of(   -1, SECONDS)));
+        assertThat(SHORT.parse(   "-01:01.000000000 minute(s)"), equalTo(Duration.of(  -61, SECONDS)));
+        assertThat(SHORT.parse("-01:01:00.000000000 hour(s)"  ), equalTo(Duration.of(  -61, MINUTES)));
+        assertThat(SHORT.parse("-01:01:01.000000000 hour(s)"  ), equalTo(Duration.of(-3661, SECONDS)));
+
+        // Without legend
+        assertThat(SHORT.parse(      "-1.100000000"), equalTo(Duration.of(-1100, MILLISECONDS)));
+        assertThat(SHORT.parse(   "-1:30.000000000"), equalTo(Duration.of(  -90, SECONDS)));
+        assertThat(SHORT.parse("-1:30:00.000000000"), equalTo(Duration.of(  -90, MINUTES)));
+    }
+    
     @Test
     void parse_shorterAndValidString_success()
     {
@@ -309,6 +407,23 @@ class DurationFormatTest
         assertThat(SHORTER.parse(    "2.2"), equalTo(Duration.of(2200, MILLISECONDS)));
         assertThat(SHORTER.parse(   "1:45"), equalTo(Duration.of( 105, SECONDS)));
         assertThat(SHORTER.parse("1:45:00"), equalTo(Duration.of( 105, MINUTES)));
+    }
+    
+    @Test
+    void parse_shorterAndValidStringNegative_success()
+    {
+        assertThat(SHORTER.parse(       "-0 second(s)"), equalTo(Duration.ZERO));
+        assertThat(SHORTER.parse(     "-0.2 second(s)"), equalTo(Duration.of( -200, MILLISECONDS)));
+        assertThat(SHORTER.parse(       "-2 second(s)"), equalTo(Duration.of(   -2, SECONDS)));
+        assertThat(SHORTER.parse(   "-01:02 minute(s)"), equalTo(Duration.of(  -62, SECONDS)));
+        assertThat(SHORTER.parse("-01:02:00 hour(s)"  ), equalTo(Duration.of(  -62, MINUTES)));
+        assertThat(SHORTER.parse("-01:01:02 hour(s)"  ), equalTo(Duration.of(-3662, SECONDS)));
+
+        // Without legend
+        assertThat(SHORTER.parse(      "-2"), equalTo(Duration.of(   -2, SECONDS)));
+        assertThat(SHORTER.parse(    "-2.2"), equalTo(Duration.of(-2200, MILLISECONDS)));
+        assertThat(SHORTER.parse(   "-1:45"), equalTo(Duration.of( -105, SECONDS)));
+        assertThat(SHORTER.parse("-1:45:00"), equalTo(Duration.of( -105, MINUTES)));
     }
 
     @Test
@@ -337,7 +452,7 @@ class DurationFormatTest
         assertThat(LINUX.parse("-1m70.000s"), equalTo(Duration.of(-130, SECONDS)));
     }
 
-    
+
     @Test
     void parse_fullAndNull_nullPointerException()
     {

--- a/src/test/java/net/obvj/performetrics/util/DurationTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationTest.java
@@ -38,17 +38,18 @@ class DurationTest
 {
 
     @Test
-    void of_validAmountAndTimeUnitAndNanosecondsPrecision_populatesAccordingly()
+    void of_positiveAmountAndTimeUnitAndNanosecondsPrecision_populatesAccordingly()
     {
         Duration td1 = Duration.of(1999888777, NANOSECONDS);
         assertThat(td1.getHours(),       is(equalTo(0L)));
         assertThat(td1.getMinutes(),     is(equalTo(0)));
         assertThat(td1.getSeconds(),     is(equalTo(1)));
         assertThat(td1.getNanoseconds(), is(equalTo(999888777)));
+        assertThat(td1.isNegative(),     is(equalTo(false)));
     }
 
     @Test
-    void of_validAmountAndTimeUnitAndSecondsPrecision_populatesAccordingly()
+    void of_positiveAmountAndTimeUnitAndSecondsPrecision_populatesAccordingly()
     {
         Duration td1 = Duration.of(5410, SECONDS);
         assertThat(td1.getHours(),       is(equalTo(1L)));
@@ -59,7 +60,7 @@ class DurationTest
     }
 
     @Test
-    void of_negativeAmount_populatesAccordingly()
+    void of_negativeAmountAndSeconds_populatesAccordingly()
     {
         Duration d1 = Duration.of(-1, SECONDS);
         assertThat(d1.getHours(),       is(equalTo(0L)));
@@ -68,6 +69,29 @@ class DurationTest
         assertThat(d1.getNanoseconds(), is(equalTo(0)));
         assertThat(d1.isNegative(),     is(equalTo(true)));
     }
+
+    @Test
+    void of_negativeAmountAndNansoseconds_populatesAccordingly()
+    {
+        Duration d1 = Duration.of(-987654321, NANOSECONDS);
+        assertThat(d1.getHours(),       is(equalTo(0L)));
+        assertThat(d1.getMinutes(),     is(equalTo(0)));
+        assertThat(d1.getSeconds(),     is(equalTo(0)));
+        assertThat(d1.getNanoseconds(), is(equalTo(987654321)));
+        assertThat(d1.isNegative(),     is(equalTo(true)));
+    }
+
+    @Test
+    void of_negativeAmountAndSecondsNansoseconds_populatesAccordingly()
+    {
+        Duration d1 = Duration.of(-2987654321L, NANOSECONDS);
+        assertThat(d1.getHours(),       is(equalTo(0L)));
+        assertThat(d1.getMinutes(),     is(equalTo(0)));
+        assertThat(d1.getSeconds(),     is(equalTo(2)));
+        assertThat(d1.getNanoseconds(), is(equalTo(987654321)));
+        assertThat(d1.isNegative(),     is(equalTo(true)));
+    }
+
 
     @Test
     void toSeconds_validValues()
@@ -205,6 +229,12 @@ class DurationTest
     }
 
     @Test
+    void equals_differentSign_false()
+    {
+        assertThat(Duration.of( 1001, MILLISECONDS).equals(Duration.of(-1001, MILLISECONDS)), is(false));
+    }
+
+    @Test
     void equals_incompatibleTypes_false()
     {
         assertThat(Duration.of(60, SECONDS).equals(new Object()), is(false));
@@ -301,7 +331,16 @@ class DurationTest
         assertParseFromToString(Duration.of(123, MINUTES));
     }
 
-    private void assertParseFromToString(Duration duration)
+    @Test
+    void parse_stringsGeneratedByToStringUsingNegativeDurations_success()
+    {
+        assertParseFromToString(Duration.of(-123, NANOSECONDS));
+        assertParseFromToString(Duration.of(-123, MILLISECONDS));
+        assertParseFromToString(Duration.of(-123, SECONDS));
+        assertParseFromToString(Duration.of(-123, MINUTES));
+    }
+
+    private static void assertParseFromToString(Duration duration)
     {
         assertThat(Duration.parse(duration.toString()), equalTo(duration));
     }

--- a/src/test/java/net/obvj/performetrics/util/DurationTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationTest.java
@@ -55,16 +55,18 @@ class DurationTest
         assertThat(td1.getMinutes(),     is(equalTo(30)));
         assertThat(td1.getSeconds(),     is(equalTo(10)));
         assertThat(td1.getNanoseconds(), is(equalTo(0)));
+        assertThat(td1.isNegative(),     is(equalTo(false)));
     }
 
     @Test
-    void of_negativeAmount_illegalArgumentException()
+    void of_negativeAmount_populatesAccordingly()
     {
         Duration d1 = Duration.of(-1, SECONDS);
         assertThat(d1.getHours(),       is(equalTo(0L)));
         assertThat(d1.getMinutes(),     is(equalTo(0)));
-        assertThat(d1.getSeconds(),     is(equalTo(-1)));
+        assertThat(d1.getSeconds(),     is(equalTo(1)));
         assertThat(d1.getNanoseconds(), is(equalTo(0)));
+        assertThat(d1.isNegative(),     is(equalTo(true)));
     }
 
     @Test


### PR DESCRIPTION
Since the support for negative durations was introduced in version 2.5.2 by #79, the `DurationFormat` class, which is responsible for the parsing and formatting of durations became unstable.

This push fixes these problems.