### PR TITLE
Performetrics.monitorOperation not returning MonitoredRunnable after an exception

### DIFF
--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -186,7 +186,13 @@ public class Performetrics
     public static MonitoredRunnable monitorOperation(Runnable runnable, Type... types)
     {
         MonitoredRunnable monitoredRunnable = new MonitoredRunnable(runnable, types);
-        monitoredRunnable.run();
-        return monitoredRunnable;
+        try
+        {
+            monitoredRunnable.run();
+        }
+        finally
+        {
+            return monitoredRunnable;
+        }
     }
 }

--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -180,8 +180,8 @@ public class Performetrics
      * <p>
      * <b>Note:</b> If the provided {@link Runnable} throws an exception during execution,
      * the method will not be able to generate the monitored {@link MonitoredRunnable}.
-     * In this case, it's recommended to use the monitored {@link MonitoredRunnable} directly
-     * the same way the method is doing.
+     * In this case, it's recommended to use the monitored {@link MonitoredRunnable} directly.
+     * Then, the exception can be handled as necessary.
      *
      * @param runnable the {@link Runnable} to be run and monitored
      * @param types    the counter types to be measured in the operation

--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -177,6 +177,12 @@ public class Performetrics
      * <b>Note:</b> If no type is specified, then all of the available types will be
      * maintained.
      *
+     * <p>
+     * <b>Note:</b> If the provided {@link Runnable} throws an exception during execution,
+     * the method will not be able to generate the monitored {@link MonitoredRunnable}.
+     * In this case, it's recommended to use the monitored {@link MonitoredRunnable} directly
+     * the same way the method is doing.
+     *
      * @param runnable the {@link Runnable} to be run and monitored
      * @param types    the counter types to be measured in the operation
      * @return the resulting {@link MonitoredRunnable}, which can be used to retrieve the
@@ -186,13 +192,7 @@ public class Performetrics
     public static MonitoredRunnable monitorOperation(Runnable runnable, Type... types)
     {
         MonitoredRunnable monitoredRunnable = new MonitoredRunnable(runnable, types);
-        try
-        {
-            monitoredRunnable.run();
-        }
-        finally
-        {
-            return monitoredRunnable;
-        }
+        monitoredRunnable.run();
+        return monitoredRunnable;
     }
 }

--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -180,7 +180,7 @@ public class Performetrics
      * <p>
      * <b>Note:</b> If the provided {@link Runnable} throws an exception during execution,
      * the method will not be able to generate the monitored {@link MonitoredRunnable}.
-     * In this case, it's recommended to use the monitored {@link MonitoredRunnable} directly.
+     * In this case, using the {@link MonitoredRunnable} class is recommended.
      * Then, the exception can be handled as necessary.
      *
      * @param runnable the {@link Runnable} to be run and monitored

--- a/src/test/java/net/obvj/performetrics/PerformetricsTest.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTest.java
@@ -21,7 +21,8 @@ import static net.obvj.performetrics.ConversionMode.DOUBLE_PRECISION;
 import static net.obvj.performetrics.ConversionMode.FAST;
 import static net.obvj.performetrics.Counter.Type.CPU_TIME;
 import static net.obvj.performetrics.Counter.Type.WALL_CLOCK_TIME;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -262,4 +263,5 @@ class PerformetricsTest
             checkAllDefaultValues();
         }
     }
+
 }

--- a/src/test/java/net/obvj/performetrics/PerformetricsTest.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTest.java
@@ -262,13 +262,4 @@ class PerformetricsTest
             checkAllDefaultValues();
         }
     }
-
-    @Test
-    void monitorOperationDoesNotReturnNullValue()
-    {
-        MonitoredRunnable monitored = Performetrics.monitorOperation(
-                () -> {throw new RuntimeException();}, WALL_CLOCK_TIME, CPU_TIME);
-        assertThat(monitored, notNullValue());
-    }
-
 }

--- a/src/test/java/net/obvj/performetrics/PerformetricsTest.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTest.java
@@ -21,8 +21,7 @@ import static net.obvj.performetrics.ConversionMode.DOUBLE_PRECISION;
 import static net.obvj.performetrics.ConversionMode.FAST;
 import static net.obvj.performetrics.Counter.Type.CPU_TIME;
 import static net.obvj.performetrics.Counter.Type.WALL_CLOCK_TIME;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -262,6 +261,14 @@ class PerformetricsTest
         {
             checkAllDefaultValues();
         }
+    }
+
+    @Test
+    void monitorOperationDoesNotReturnNullValue()
+    {
+        MonitoredRunnable monitored = Performetrics.monitorOperation(
+                () -> {throw new RuntimeException();}, WALL_CLOCK_TIME, CPU_TIME);
+        assertThat(monitored, notNullValue());
     }
 
 }


### PR DESCRIPTION
Fixing the problem that occurs with the monitorOperation method on the Performetrics class when the Runnable provided as parameter throw an exception

This pull request should fix the issue #83 