### PR TITLE
New facade method Performetrics.configuration()

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml --no-transfer-progress
     - name: Upload to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         java_version: [ 11, 17, 21 ]

--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ Performetrics provides two different conversion modes that can be applied depend
 
 * **Fast conversion**: uses Java-standard classes to convert durations to different time units. Although conversions in this mode are extremely fast, those from finer to coarser granularities truncate, so lose precision. For example, converting 999 milliseconds to seconds results in 0 (worst case).
 
-  To set this mode, call `Performetrics.setDefaultConversionMode(ConversionMode.FAST)`.  
+  To set this mode, call `Performetrics.configuration().setDefaultConversionMode(ConversionMode.FAST)`.  
 
 * **Double-precision (default)**: implements a more robust conversion logic that avoids truncation from finer to coarser granularity. For example, converting 999 milliseconds to seconds results in 0.999
 
-  A initial precision of 9 decimal places is set by default. This property can be changed calling `Performetrics.setScale(int)`.
+  A initial precision of 9 decimal places is set by default. This property can be changed calling `Performetrics.configuration().setScale(int)`.
 
 > **Note:** Check the  **[Javadoc](https://javadoc.io/doc/net.obvj/performetrics)** to find out how to specify a different conversion mode for a single operation.
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Test dependencies versions -->
-        <junit.version>5.10.1</junit.version>
+        <junit.version>5.10.2</junit.version>
         <junit-utils.version>1.7.0</junit-utils.version>
-        <mockito.version>5.10.0</mockito.version>
+        <mockito.version>5.11.0</mockito.version>
         <snakeyaml.version>2.2</snakeyaml.version>
     </properties>
 
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.11</version>
+                <version>0.8.12</version>
                 <executions>
                     <execution>
                         <goals>
@@ -116,7 +116,7 @@
 
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>default-deploy</id>
@@ -162,7 +162,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -19,6 +19,7 @@ package net.obvj.performetrics;
 import java.util.List;
 
 import net.obvj.performetrics.Counter.Type;
+import net.obvj.performetrics.config.Configuration;
 import net.obvj.performetrics.config.ConfigurationHolder;
 import net.obvj.performetrics.monitors.MonitoredRunnable;
 import net.obvj.performetrics.util.print.PrintStyle;
@@ -49,11 +50,26 @@ public class Performetrics
     }
 
     /**
+     * Returns the current {@link Configuration}.
+     *
+     * @return the current configuration
+     * @since 2.5.3
+     */
+    public Configuration configuration()
+    {
+        return ConfigurationHolder.getConfiguration();
+    }
+
+    /**
      * Sets a conversion mode to be applied by supported operations if no specific mode is
      * set.
      *
      * @param conversionMode the {@link ConversionMode} to set
+     *
+     * @deprecated Use {@code Performetrics.configuration().setConversionMode(ConversionMode)}
+     *             instead.
      */
+    @Deprecated(since = "2.5.3", forRemoval = true)
     public static void setDefaultConversionMode(ConversionMode conversionMode)
     {
         ConfigurationHolder.getConfiguration().setConversionMode(conversionMode);
@@ -65,7 +81,10 @@ public class Performetrics
      *
      * @param scale a number between 0 and 16 to be set
      * @throws IllegalArgumentException if a number outside the allowed range is received
+     *
+     * @deprecated Use {@code Performetrics.configuration().setScale(int)} instead.
      */
+    @Deprecated(since = "2.5.3", forRemoval = true)
     public static void setScale(int scale)
     {
         ConfigurationHolder.getConfiguration().setScale(scale);
@@ -85,7 +104,11 @@ public class Performetrics
      * @throws NullPointerException if the specified {@code PrintStyle} is null
      *
      * @since 2.4.0
+     *
+     * @deprecated Use {@code Performetrics.configuration().setPrintStyle(PrintStyle)}
+     *             instead.
      */
+    @Deprecated(since = "2.5.3", forRemoval = true)
     public static void setDefaultPrintStyle(PrintStyle printStyle)
     {
         ConfigurationHolder.getConfiguration().setPrintStyle(printStyle);
@@ -105,7 +128,12 @@ public class Performetrics
      * @throws NullPointerException if the specified {@code PrintStyle} is null
      *
      * @since 2.2.1
+     *
+     * @deprecated Use
+     *             {@code Performetrics.configuration().setPrintStyleForSummary(PrintStyle)}
+     *             instead.
      */
+    @Deprecated(since = "2.5.3", forRemoval = true)
     public static void setDefaultPrintStyleForSummary(PrintStyle printStyle)
     {
         ConfigurationHolder.getConfiguration().setPrintStyleForSummary(printStyle);
@@ -125,7 +153,12 @@ public class Performetrics
      * @throws NullPointerException if the specified {@code PrintStyle} is null
      *
      * @since 2.2.1
+     *
+     * @deprecated Use
+     *             {@code Performetrics.configuration().setPrintStyleForDetails(PrintStyle)}
+     *             instead.
      */
+    @Deprecated(since = "2.5.3", forRemoval = true)
     public static void setDefaultPrintStyleForDetails(PrintStyle printStyle)
     {
         ConfigurationHolder.getConfiguration().setPrintStyleForDetails(printStyle);
@@ -141,8 +174,12 @@ public class Performetrics
      *
      * <pre>
      * {@code MonitoredRunnable runnable =}
-     * {@code         Performetrics.monitorOperation(() -> myObj.exec());}
-     * {@code Duration elapsedTime = runnable.elapsedTime(Type.WALL_CLOCK_TIME);}
+     * {@code
+     * Performetrics.monitorOperation(() -> myObj.exec());
+     * }
+     * {@code
+     * Duration elapsedTime = runnable.elapsedTime(Type.WALL_CLOCK_TIME);
+     * }
      * </pre>
      *
      * </blockquote>

--- a/src/main/java/net/obvj/performetrics/Performetrics.java
+++ b/src/main/java/net/obvj/performetrics/Performetrics.java
@@ -55,7 +55,7 @@ public class Performetrics
      * @return the current configuration
      * @since 2.5.3
      */
-    public Configuration configuration()
+    public static Configuration configuration()
     {
         return ConfigurationHolder.getConfiguration();
     }

--- a/src/test/java/net/obvj/performetrics/PerformetricsTest.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -63,16 +62,11 @@ class PerformetricsTest
         runFlag = true;
     };
 
-    @BeforeEach
-    void setup()
-    {
-        ConfigurationHolder.reset();
-    }
-
     @AfterEach
     void resetFlag()
     {
         runFlag = false;
+        ConfigurationHolder.reset();
     }
 
     private void checkAllDefaultValues()
@@ -268,6 +262,12 @@ class PerformetricsTest
         {
             checkAllDefaultValues();
         }
+    }
+
+    @Test
+    void configuration_getCurrentConfiguration()
+    {
+        assertThat(Performetrics.configuration(), equalTo(ConfigurationHolder.getConfiguration()));
     }
 
 }

--- a/src/test/java/net/obvj/performetrics/PerformetricsTest.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -62,11 +63,16 @@ class PerformetricsTest
         runFlag = true;
     };
 
+    @BeforeEach
+    void setup()
+    {
+        ConfigurationHolder.reset();
+    }
+
     @AfterEach
     void resetFlag()
     {
         runFlag = false;
-        ConfigurationHolder.reset();
     }
 
     private void checkAllDefaultValues()

--- a/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
+++ b/src/test/java/net/obvj/performetrics/PerformetricsTestDrive.java
@@ -46,13 +46,13 @@ public class PerformetricsTestDrive
         testStopwatch1();
         System.out.println("\n\n****************************************************\n");
         System.out.println("Now in fast mode...\n");
-        Performetrics.setDefaultConversionMode(ConversionMode.FAST);
+        Performetrics.configuration().setConversionMode(ConversionMode.FAST);
         testStopwatch1();
 
         System.out.println("\n\n****************************************************\n");
         System.out.println("Now with a custom scale...\n");
-        Performetrics.setDefaultConversionMode(ConversionMode.DOUBLE_PRECISION);
-        Performetrics.setScale(2);
+        Performetrics.configuration().setConversionMode(ConversionMode.DOUBLE_PRECISION);
+        Performetrics.configuration().setScale(2);
 
         System.out.println("\n\n****************************************************\n");
         testCallableWithLambda();

--- a/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
+++ b/src/test/java/net/obvj/performetrics/util/print/PrintUtilsTest.java
@@ -63,7 +63,7 @@ class PrintUtilsTest
     {
         ALL_COUNTERS.put(WALL_CLOCK_TIME, singletonList(C1));
         ALL_COUNTERS.put(CPU_TIME, singletonList(C2));
-        Performetrics.setDefaultPrintStyle(DEFAULT_PRINT_STYLE);
+        Performetrics.configuration().setPrintStyle(DEFAULT_PRINT_STYLE);
     }
 
     Stopwatch stopwatch = mock(Stopwatch.class);


### PR DESCRIPTION
There's an unwanted behavior running builds and tests only when using the stack: Ubuntu 22.04, Temurin JDK 17, and Mockito: tests equality tests on the PerformetricsTest class (internal) started to fail.
While testing with Windows 11 and the Temurin JDK 17, the problem did not happen, so I decided to **temporarily downgrade** the Linux version in GitHub actions to 20.04 LTS. That solved the problem.

However, to remove the temporary restriction and keep moving forward, I must first deprecate a few methods from the `Performetrics` class for further removal. These are "shortcut" methods for a few setters inside the current `Configuration` object in the class `Configuration`. While these are not exactly a problem, they're complicated to be tested by the unit/mock libraries.

A new method `configuration()` now allows the retrieval of the current `Configuration`, and the users can use the setter methods directly on that class (so, no need to duplicate the methods in the façade class when a new configuration attribute is added, from now on):

`Performetrics.setDefaultScale(9); // deprecated (to be removed in version 2.7.x)` 
`Performetrics.configuration().setScale(9); // new way to go`

The upgrade to the latest Ubuntu version in the CI/CD setup can be done from 2.7.0 on, as soon as the deprecated methods are removed.


