### PR TITLE
Introduce DurationUtils.analyzeDurations()

### DIFF
--- a/src/main/java/net/obvj/performetrics/util/DurationStats.java
+++ b/src/main/java/net/obvj/performetrics/util/DurationStats.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.performetrics.util;
+
+import java.util.Objects;
+
+/**
+ * A class that represents statistical metrics for durations, such as average, minimum,
+ * and maximum.
+ *
+ * <p>
+ * This class is immutable and provides a convenient way to encapsulate the calculated
+ * duration statistics. If no values are provided, default values of {@link Duration#ZERO}
+ * are used.
+ *
+ * <p>
+ * An empty object is available as {@link DurationStats#EMPTY}.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 2.6.0
+ */
+public final class DurationStats
+{
+
+    /**
+     * A constant representing an empty {@code DurationStats} instance with all metrics set to
+     * {@link Duration#ZERO}.
+     */
+    public static final DurationStats EMPTY = new DurationStats(null, null, null);
+
+    private final Duration average;
+    private final Duration min;
+    private final Duration max;
+
+    /**
+     * Constructs a new {@code DurationStats} object with the specified average, minimum, and
+     * maximum durations.
+     *
+     * <p>
+     * If any of the parameters are {@code null}, they are replaced with
+     * {@link Duration#ZERO}.
+     *
+     * @param average the average duration, or {@code null} to default to
+     *                {@link Duration#ZERO}.
+     * @param min     the minimum duration, or {@code null} to default to
+     *                {@link Duration#ZERO}.
+     * @param max     the maximum duration, or {@code null} to default to
+     *                {@link Duration#ZERO}.
+     */
+    public DurationStats(Duration average, Duration min, Duration max)
+    {
+        this.average = Objects.requireNonNullElse(average, Duration.ZERO);
+        this.min = Objects.requireNonNullElse(min, Duration.ZERO);
+        this.max = Objects.requireNonNullElse(max, Duration.ZERO);
+    }
+
+    /**
+     * Returns the average duration.
+     *
+     * @return the average duration, never {@code null}; defaults to {@link Duration#ZERO} if
+     *         not set.
+     */
+    public Duration average()
+    {
+        return average;
+    }
+
+    /**
+     * Returns the minimum duration.
+     *
+     * @return the minimum duration, never {@code null}; defaults to {@link Duration#ZERO} if
+     *         not set.
+     */
+    public Duration min()
+    {
+        return min;
+    }
+
+    /**
+     * Returns the maximum duration.
+     *
+     * @return the maximum duration, never {@code null}; defaults to {@link Duration#ZERO} if
+     *         not set.
+     */
+    public Duration max()
+    {
+        return max;
+    }
+
+}

--- a/src/main/java/net/obvj/performetrics/util/DurationUtils.java
+++ b/src/main/java/net/obvj/performetrics/util/DurationUtils.java
@@ -26,9 +26,84 @@ import java.util.Collection;
  */
 public class DurationUtils
 {
+
     private DurationUtils()
     {
         throw new IllegalStateException("Instantiation not allowed");
+    }
+
+    /**
+     * Calculates statistical metrics (average, minimum, and/or maximum) for a collection of
+     * durations based on the specified flags.
+     * <p>
+     * The flags are represented as bitwise values, and their combination determines the
+     * calculations performed.
+     * <p>
+     * Examples of usage:
+     *
+     * <pre>
+     * // Example 1: Calculate the average duration
+     * DurationStats stats = calculateStats(durations, StatFlags.AVERAGE);
+     *
+     * // Example 2: Calculate the minimum and maximum durations
+     * DurationStats stats = calculateStats(durations, StatFlags.MIN | Flag.MAX);
+     *
+     * // Example 3: Calculate all statistics
+     * DurationStats stats = calculateStats(durations, StatFlags.ALL);
+     * </pre>
+     *
+     * <p>
+     * <b>Note:</b> If the input collection is empty or null, {@link DurationStats#EMPTY} is returned.
+     *
+     * @param durations the collection of {@link Duration} objects to analyze (null is
+     *                  allowed).
+     * @param flags     an integer representing the enabled flags using bitwise values.
+     *                  Supported flags are:
+     *                  <ul>
+     *                  <li>{@link StatFlags#AVERAGE} - Calculate the average duration.</li>
+     *                  <li>{@link StatFlags#MIN} - Calculate the minimum duration.</li>
+     *                  <li>{@link StatFlags#MAX} - Calculate the maximum duration.</li>
+     *                  <li>{@link StatFlags#ALL} - Calculates all statistics.</li>
+     *                  </ul>
+     * @return a {@link DurationStats} object containing the calculated metrics.
+     * @since 2.6.0
+     */
+    public static DurationStats analyzeDurations(Collection<Duration> durations, int flags)
+    {
+        if (isEmpty(durations))
+        {
+            return DurationStats.EMPTY;
+        }
+
+        boolean calculateAverage = StatFlags.isEnabled(StatFlags.AVERAGE, flags);
+        boolean calculateMin = StatFlags.isEnabled(StatFlags.MIN, flags);
+        boolean calculateMax = StatFlags.isEnabled(StatFlags.MAX, flags);
+
+        Duration sum = Duration.ZERO;
+        Duration min = null;
+        Duration max = null;
+        int count = 0;
+
+        for (Duration duration : durations)
+        {
+            if (duration == null) continue; // Skip null values
+            if (calculateAverage)
+            {
+                sum = sum.plus(duration);
+                count++;
+            }
+            if (calculateMin)
+            {
+                min = min == null || duration.compareTo(min) < 0 ? duration : min;
+            }
+            if (calculateMax)
+            {
+                max = max == null || duration.compareTo(max) > 0 ? duration : max;
+            }
+        }
+
+        Duration average = calculateAverage && count > 0 ? sum.dividedBy(count) : Duration.ZERO;
+        return new DurationStats(average, min, max);
     }
 
     /**
@@ -40,22 +115,7 @@ public class DurationUtils
      */
     public static Duration average(Collection<Duration> durations)
     {
-        if (isEmpty(durations))
-        {
-            return Duration.ZERO;
-        }
-        Duration sum = Duration.ZERO;
-        // The count is important as we skip possible null elements inside the collection
-        int count = 0;
-        for (Duration element : durations)
-        {
-            if (element != null)
-            {
-                sum = sum.plus(element);
-                count++;
-            }
-        }
-        return count == 0 ? Duration.ZERO : sum.dividedBy(count);
+        return analyzeDurations(durations, StatFlags.AVERAGE).average();
     }
 
     /**
@@ -67,12 +127,7 @@ public class DurationUtils
      */
     public static Duration min(Collection<Duration> durations)
     {
-        if (isEmpty(durations))
-        {
-            return Duration.ZERO;
-        }
-        // We compare the seconds with the fractional nanoseconds after the decimal point
-        return durations.stream().min(Comparable::compareTo).orElse(Duration.ZERO);
+        return analyzeDurations(durations, StatFlags.MIN).min();
     }
 
     /**
@@ -84,12 +139,7 @@ public class DurationUtils
      */
     public static Duration max(Collection<Duration> durations)
     {
-        if (isEmpty(durations))
-        {
-            return Duration.ZERO;
-        }
-        // We compare the seconds with the fractional nanoseconds after the decimal point
-        return durations.stream().max(Comparable::compareTo).orElse(Duration.ZERO);
+        return analyzeDurations(durations, StatFlags.MAX).max();
     }
 
     private static boolean isEmpty(Collection<?> collection)

--- a/src/main/java/net/obvj/performetrics/util/StatFlags.java
+++ b/src/main/java/net/obvj/performetrics/util/StatFlags.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.performetrics.util;
+
+/**
+ * A utility class for handling statistical flags.
+ *
+ * <p>
+ * Each flag represents a specific statistical operation and can be combined using bitwise
+ * OR operations. This class provides constants for the flags and a utility method to
+ * check if a specific flag is enabled.
+ *
+ * <p>
+ * Usage example:
+ *
+ * <pre>
+ * int flags = StatFlags.AVERAGE | StatFlags.MIN; // Enable AVERAGE and MIN flags
+ * boolean isAverageEnabled = StatFlags.isEnabled(StatFlags.AVERAGE, flags); // true
+ * boolean isMaxEnabled = StatFlags.isEnabled(StatFlags.MAX, flags); // false
+ * </pre>
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 2.6.0
+ */
+public class StatFlags
+{
+    /**
+     * Flag representing the calculation of the average. Binary: {@code 0b001}.
+     */
+    public static final int AVERAGE = 0b001;
+    /**
+     * Flag representing the calculation of the minimum. Binary: {@code 0b010}.
+     */
+    public static final int MIN = 0b010;
+    /**
+     * Flag representing the calculation of the maximum. Binary: {@code 0b100}.
+     */
+    public static final int MAX = 0b100;
+    /**
+     * Flag enabling all calculations: average, minimum, and maximum. Binary: {@code 0b111}.
+     */
+    public static final int ALL = 0b111;
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     *
+     * @throws IllegalStateException if instantiation is attempted.
+     */
+    private StatFlags()
+    {
+        throw new IllegalStateException("Instantiation not allowed");
+    }
+
+    /**
+     * Checks whether a specific flag is enabled in the given combination of flags.
+     * <p>
+     * Usage example:
+     *
+     * <pre>
+     * int flags = StatFlags.AVERAGE | StatFlags.MIN;
+     * boolean isAverageEnabled = StatFlags.isEnabled(StatFlags.AVERAGE, flags); // true
+     * boolean isMaxEnabled = StatFlags.isEnabled(StatFlags.MAX, flags); // false
+     * </pre>
+     *
+     * @param flag  the flag to check, such as {@link StatFlags#AVERAGE},
+     *              {@link StatFlags#MIN}, or {@link StatFlags#MAX}.
+     * @param flags the combined flags to check against, typically created using bitwise OR
+     *              operations.
+     * @return {@code true} if the specified flag is enabled; {@code false} otherwise.
+     */
+    public static boolean isEnabled(int flag, int flags)
+    {
+        return (flags & flag) != 0;
+    }
+}

--- a/src/test/java/net/obvj/performetrics/util/DurationUtilsTest.java
+++ b/src/test/java/net/obvj/performetrics/util/DurationUtilsTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
@@ -140,6 +142,16 @@ class DurationUtilsTest
     {
         assertThat(max(Arrays.asList(D_750_MILLIS, D_1_SECOND)), is(equalTo(D_1_SECOND)));
         assertThat(max(Arrays.asList(D_750_MILLIS, D_2_SECONDS, D_500_MILLIS)), is(equalTo(D_2_SECONDS)));
+    }
+
+    @Test
+    void analyzeDurations_multipleValuesAndAllFlags_validMetrics()
+    {
+        List<Duration> durations = Arrays.asList(D_1_SECOND, D_2_SECONDS, D_500_MILLIS, D_1250_MILLIS);
+        DurationStats stats = DurationUtils.analyzeDurations(durations, StatFlags.ALL);
+        assertThat(stats.average(), equalTo(Duration.of(1_187_500_000, TimeUnit.NANOSECONDS)));
+        assertThat(stats.min(), equalTo(D_500_MILLIS));
+        assertThat(stats.max(), equalTo(D_2_SECONDS));
     }
 
 }

--- a/src/test/java/net/obvj/performetrics/util/StatFlagsTest.java
+++ b/src/test/java/net/obvj/performetrics/util/StatFlagsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.obvj.performetrics.util;
+
+import static net.obvj.junit.utils.matchers.AdvancedMatchers.instantiationNotAllowed;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link StatFlags} class.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 2.6.0
+ */
+class StatFlagsTest
+{
+
+    @Test
+    void constructor_instantiationNotAllowed()
+    {
+        assertThat(StatFlags.class, instantiationNotAllowed().throwing(IllegalStateException.class)
+                .withMessage("Instantiation not allowed"));
+    }
+
+    @Test
+    void isFlagEnabled_severalCombinations()
+    {
+        int myFlags = StatFlags.MIN | StatFlags.MAX;
+        assertThat(StatFlags.isEnabled(StatFlags.AVERAGE, myFlags), equalTo(false));
+        assertThat(StatFlags.isEnabled(StatFlags.MIN, myFlags), equalTo(true));
+        assertThat(StatFlags.isEnabled(StatFlags.MAX, myFlags), equalTo(true));
+
+        int allFlags = StatFlags.ALL;
+        assertThat(StatFlags.isEnabled(StatFlags.AVERAGE, allFlags), equalTo(true));
+        assertThat(StatFlags.isEnabled(StatFlags.MIN, allFlags), equalTo(true));
+        assertThat(StatFlags.isEnabled(StatFlags.MAX, allFlags), equalTo(true));
+    }
+
+}


### PR DESCRIPTION
Enhancement: Add utility and data classes for duration statistics and flag-based calculations

- Enhanced `DurationUtils` with bitmap-based and bitwise flag-based logic for average, min, and max calculations.

- Added `StatFlags` class for managing statistical flags with constants and utility methods.
  - Supports bitwise operations for average, min, and max calculations.
  - Includes the `isEnabled` method to check flag activation.

- Added `DurationStats` immutable value object for encapsulating average, min, and max durations.
  - Includes `EMPTY` constant for default instance with zero values.
  - Provides getter methods for average, min, and max durations.

- Added Javadocs for all classes, fields, and methods, including usage examples.