### PR TITLE
GH Actions Ubuntu 20.04 runner deprecation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         java_version: [ 11, 17, 21 ]

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         java_version: [ 11, 17, 21 ]


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/11101, The Ubuntu 20.04 Actions runner deprecation started on 2025-02. So Performetrics build workflow must be updated to the latest Linux runner available -- Ubuntu 24.04. 